### PR TITLE
Add detailed .ftproj docs with German translation

### DIFF
--- a/docs/ftproj_format.md
+++ b/docs/ftproj_format.md
@@ -1,0 +1,122 @@
+# .ftproj Format
+
+The `.ftproj` file is a serialized representation of a fine‑tune project. The same data can also be saved as textual JSON with the `.json` extension. Each project root contains three keys:
+
+```json
+{
+  "functions": [],
+  "conversations": {},
+  "settings": {}
+}
+```
+
+Each section is described below along with the meaning of every field.
+
+## Root keys
+- **`functions`**: Array of function definitions used when exporting or testing conversations.
+- **`conversations`**: Dictionary mapping a conversation ID to an array of message objects.
+- **`settings`**: Global configuration options for the project.
+
+## Function entries
+
+Each item of the `functions` array describes one callable function.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | The function's public name used in API calls. |
+| `description` | string | Human readable description shown in UIs. |
+| `parameters` | array | List of parameter definitions. |
+| `functionExecutionEnabled` | bool | Whether the function can be executed by the program. |
+| `functionExecutionExecutable` | string | Path or command to run the function if execution is enabled. |
+| `functionExecutionArgumentsString` | string | Arguments passed when running the executable. |
+
+### Parameter objects
+
+Each object inside the `parameters` array defines one argument.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | string | Allowed value type, e.g. `String` or `Number`. |
+| `name` | string | Parameter name. |
+| `description` | string | Explanation of the parameter. |
+| `minimum` | number | Lowest allowed numeric value. |
+| `maximum` | number | Highest allowed numeric value. |
+| `isEnum` | bool | Indicates if the value must be chosen from `enumOptions`. |
+| `hasLimits` | bool | Whether `minimum` and `maximum` are enforced. |
+| `enumOptions` | string | Comma separated allowed choices when `isEnum` is `true`. |
+| `isRequired` | bool | If `true`, the parameter must be provided. |
+
+## Conversations
+
+The `conversations` dictionary stores all recorded dialogues. The key is the conversation ID and the value is a list of messages.
+
+### Message objects
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `role` | string | Sender of the message: `system`, `user`, `assistant`, or `meta`. |
+| `type` | string | Message content type such as `Text` or `Image`. |
+| `textContent` | string | Text body shown to the model. |
+| `unpreferredTextContent` | string | Alternative text that was not used. |
+| `preferredTextContent` | string | Preferred alternative text. |
+| `imageContent` | string | Base64 encoded image data. |
+| `imageDetail` | integer | Level of detail for image processing. |
+| `functionName` | string | Name of the function call to make. |
+| `functionParameters` | array | List of function argument objects. |
+| `functionResults` | string | Results returned by an executed function. |
+| `functionUsePreText` | string | Text prepended when executing a function. |
+| `userName` | string | Optional user display name. |
+| `jsonSchemaValue` | string | Additional schema information. |
+| `metaData` | object | Information about the conversation itself. |
+| `audioData` | string | Base64 encoded audio data. |
+| `audioTranscript` | string | Transcript of the audio. |
+| `audioFiletype` | string | File extension of the audio data. |
+| `fileMessageData` | string | Base64 encoded file attached to the message. |
+| `fileMessageName` | string | Name of the attached file. |
+
+#### Function parameter objects
+
+Within a message, each entry of `functionParameters` uses the structure below.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Name of the parameter. |
+| `isUsed` | bool | Whether the value should be included. |
+| `parameterValueText` | string | Text value selected by the user. |
+| `parameterValueChoice` | string | Enumeration choice selected by the user. |
+| `parameterValueNumber` | number | Numeric value selected by the user. |
+
+#### `metaData` object
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ready` | bool | Indicates that the conversation is finished and ready for export. |
+| `conversationName` | string | Optional label for the conversation. |
+| `notes` | string | Arbitrary notes about the conversation. |
+
+## Settings
+
+Global configuration stored in the `settings` object.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `useGlobalSystemMessage` | bool | Prepend a single system message to all conversations. |
+| `globalSystemMessage` | string | Text of the global system message. |
+| `apikey` | string | Stored API key for OpenAI requests. |
+| `modelChoice` | string | Selected model for token counting or completions. |
+| `availableModels` | array | List of models available to the user. |
+| `includeFunctions` | integer | Determines when functions are included during export. |
+| `finetuneType` | integer | Selected fine‑tuning method. |
+| `exportImagesHow` | integer | How image messages are exported. |
+| `useUserNames` | bool | Include user names in exported data. |
+| `schemaEditorURL` | string | URL to an external JSON schema editor. |
+| `jsonSchema` | string | Default JSON schema used for validation. |
+| `tokenCounterPath` | string | Path to an external token counting tool. |
+| `exportConvos` | integer | Determines which conversations are exported. |
+| `countTokensWhen` | integer | Specifies when token counting is performed. |
+| `tokenCounts` | string | Cached token counts per conversation. |
+| `countTokensModel` | integer | Model used to estimate token counts. |
+
+### Binary vs JSON
+
+When saved with the `.ftproj` extension, the entire object is serialized with Godot's `store_var`. Using `.json` saves the same structure as plain JSON text.

--- a/docs/ftproj_format_de.md
+++ b/docs/ftproj_format_de.md
@@ -1,0 +1,122 @@
+# .ftproj Format (Deutsch)
+
+Die Datei `.ftproj` speichert ein Fine‑Tune‑Projekt in serialisierter Form. Die gleichen Daten können auch als JSON mit der Endung `.json` abgelegt werden. Die Wurzelstruktur enthält drei Schlüssel:
+
+```json
+{
+  "functions": [],
+  "conversations": {},
+  "settings": {}
+}
+```
+
+Nachfolgend werden alle Bereiche sowie die Bedeutung der einzelnen Felder erläutert.
+
+## Wurzelschlüssel
+- **`functions`**: Liste von Funktionsdefinitionen, die beim Export oder Testen genutzt werden.
+- **`conversations`**: Dictionary, das eine Konversations‑ID auf eine Liste von Nachrichten abbildet.
+- **`settings`**: Globale Einstellungen des Projekts.
+
+## Funktionsobjekte
+
+Jeder Eintrag in `functions` beschreibt eine aufrufbare Funktion.
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `name` | string | Öffentlicher Name der Funktion. |
+| `description` | string | Lesbare Beschreibung für Benutzeroberflächen. |
+| `parameters` | array | Liste der Parameterdefinitionen. |
+| `functionExecutionEnabled` | bool | Ob die Funktion vom Programm ausgeführt werden darf. |
+| `functionExecutionExecutable` | string | Pfad oder Kommando, das bei Ausführung gestartet wird. |
+| `functionExecutionArgumentsString` | string | Argumente, die dem Kommando übergeben werden. |
+
+### Parameterobjekte
+
+Jedes Objekt im Array `parameters` definiert ein Argument.
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `type` | string | Erlaubter Wertetyp wie `String` oder `Number`. |
+| `name` | string | Name des Parameters. |
+| `description` | string | Erläuterung des Parameters. |
+| `minimum` | number | Kleinster zulässiger numerischer Wert. |
+| `maximum` | number | Größter zulässiger numerischer Wert. |
+| `isEnum` | bool | Gibt an, ob der Wert aus `enumOptions` gewählt werden muss. |
+| `hasLimits` | bool | Ob `minimum` und `maximum` gelten. |
+| `enumOptions` | string | Kommagetrennte erlaubte Auswahlmöglichkeiten. |
+| `isRequired` | bool | Muss dieser Parameter angegeben werden. |
+
+## Gespräche
+
+Im Dictionary `conversations` werden alle aufgezeichneten Dialoge gespeichert. Der Schlüssel ist die Konversations‑ID, der Wert eine Liste von Nachrichten.
+
+### Nachrichtenobjekte
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `role` | string | Absender: `system`, `user`, `assistant` oder `meta`. |
+| `type` | string | Inhaltstyp wie `Text` oder `Image`. |
+| `textContent` | string | Text, der dem Modell gezeigt wird. |
+| `unpreferredTextContent` | string | Alternative, die nicht verwendet wurde. |
+| `preferredTextContent` | string | Bevorzugte Alternative. |
+| `imageContent` | string | Base64‑kodierte Bilddaten. |
+| `imageDetail` | integer | Detailstufe für die Bildverarbeitung. |
+| `functionName` | string | Name des aufzurufenden Funktionsaufrufs. |
+| `functionParameters` | array | Liste von Funktionsparametern. |
+| `functionResults` | string | Ergebnis einer ausgeführten Funktion. |
+| `functionUsePreText` | string | Text, der bei der Ausführung vorangestellt wird. |
+| `userName` | string | Optionaler Benutzername. |
+| `jsonSchemaValue` | string | Zusätzliche Schema‑Informationen. |
+| `metaData` | object | Informationen zur Konversation selbst. |
+| `audioData` | string | Base64‑kodierte Audiodaten. |
+| `audioTranscript` | string | Transkription des Audios. |
+| `audioFiletype` | string | Dateiendung der Audiodaten. |
+| `fileMessageData` | string | Base64‑kodierte Datei im Anhang. |
+| `fileMessageName` | string | Name der angehängten Datei. |
+
+#### Funktionsparameterobjekte
+
+Innerhalb einer Nachricht hat jedes Element von `functionParameters` folgende Struktur.
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `name` | string | Name des Parameters. |
+| `isUsed` | bool | Ob der Wert verwendet werden soll. |
+| `parameterValueText` | string | Textwert, der gewählt wurde. |
+| `parameterValueChoice` | string | Ausgewählte Option einer Enumeration. |
+| `parameterValueNumber` | number | Gewählter numerischer Wert. |
+
+#### `metaData`-Objekt
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `ready` | bool | Zeigt an, dass das Gespräch fertig und exportbereit ist. |
+| `conversationName` | string | Optionale Bezeichnung der Konversation. |
+| `notes` | string | Beliebige Notizen zum Gespräch. |
+
+## Einstellungen
+
+Globale Konfiguration, gespeichert im Objekt `settings`.
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `useGlobalSystemMessage` | bool | Fügt allen Gesprächen eine gemeinsame Systemnachricht voran. |
+| `globalSystemMessage` | string | Text dieser globalen Systemnachricht. |
+| `apikey` | string | Gespeicherter API-Schlüssel für OpenAI. |
+| `modelChoice` | string | Gewähltes Modell für Tokenzählung oder Antworten. |
+| `availableModels` | array | Liste der verfügbaren Modelle. |
+| `includeFunctions` | integer | Legt fest, wann Funktionen exportiert werden. |
+| `finetuneType` | integer | Gewählte Fine‑Tune‑Methode. |
+| `exportImagesHow` | integer | Art und Weise des Bildexports. |
+| `useUserNames` | bool | Benutzernamen in exportierten Daten einbeziehen. |
+| `schemaEditorURL` | string | URL zu einem externen JSON-Schema-Editor. |
+| `jsonSchema` | string | Standard‑JSON-Schema zur Validierung. |
+| `tokenCounterPath` | string | Pfad zu einem externen Tool zur Tokenzählung. |
+| `exportConvos` | integer | Welche Gespräche exportiert werden. |
+| `countTokensWhen` | integer | Wann die Tokenzählung erfolgt. |
+| `tokenCounts` | string | Zwischengespeicherte Tokenzahlen pro Gespräch. |
+| `countTokensModel` | integer | Modell zur Schätzung der Tokenanzahl. |
+
+### Binär vs. JSON
+
+Bei Speicherung als `.ftproj` wird das komplette Objekt mit Godots `store_var` serialisiert. Mit `.json` wird dieselbe Struktur als JSON‑Text geschrieben.


### PR DESCRIPTION
## Summary
- document every field in the `.ftproj` project format
- provide a German translation of the documentation

## Testing
- `pytest -q`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405e83b5408320947894a31a8f9b11