### PR TITLE
Add basic Godot unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Godot
-        uses: firebelley/setup-godot@v1
+        uses: chickensoft-games/setup-godot@v2
         with:
           version: 4.4.1
-          export-templates: false
+          use-dotnet: false
+          include-templates: false
       - name: Run tests
         run: godot --headless --path src -s res://tests/test_import_openai.gd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Run Godot Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Godot
+        uses: firebelley/setup-godot@v1
+        with:
+          version: 4.4.1
+          export-templates: false
+      - name: Run tests
+        run: godot --headless --path src -s res://tests/test_import_openai.gd

--- a/src/tests/dummy_file_access_web.gd
+++ b/src/tests/dummy_file_access_web.gd
@@ -1,0 +1,2 @@
+extends RefCounted
+class_name FileAccessWeb


### PR DESCRIPTION
## Summary
- add simple dummy class to satisfy plugin dependency
- add `test_import_openai.gd` with basic tests for conversion helpers and save/load logic
- add GitHub Action to run the tests on PRs

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`


------
https://chatgpt.com/codex/tasks/task_e_685983016b4883208ed27a6716966fcf