### PR TITLE
Remove dummy FileAccessWeb class from tests

### DIFF
--- a/src/tests/dummy_file_access_web.gd
+++ b/src/tests/dummy_file_access_web.gd
@@ -1,2 +1,0 @@
-extends RefCounted
-class_name FileAccessWeb

--- a/src/tests/test_import_openai.gd
+++ b/src/tests/test_import_openai.gd
@@ -1,7 +1,5 @@
 extends SceneTree
 
-# Ensure required classes are available when loading project scripts
-const _DummyFileAccessWeb = preload("res://tests/dummy_file_access_web.gd")
 
 var tests_run := 0
 var tests_failed := 0


### PR DESCRIPTION
## Summary
- remove `dummy_file_access_web.gd` test stub that overrode the real FileAccessWeb
- drop preload reference in tests

## Testing
- `godot --headless --no-window --path . -s tests/test_import_openai.gd`

------
https://chatgpt.com/codex/tasks/task_e_6859ce4d3a348320a3ac1692cceb93eb