### PR TITLE
Add basic runtime tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,7 @@ jobs:
           use-dotnet: false
           include-templates: false
       - name: Run tests
-        run: godot --headless --path src -s res://tests/test_import_openai.gd
+        run: |
+          godot --headless --path src -s res://tests/test_import_openai.gd && \
+          godot --headless --path src -s res://tests/test_application_start.gd && \
+          godot --headless --path src -s res://tests/test_load_examples.gd

--- a/src/tests/test_application_start.gd
+++ b/src/tests/test_application_start.gd
@@ -1,0 +1,10 @@
+extends SceneTree
+
+func _init():
+    call_deferred("_run")
+
+func _run():
+    change_scene_to_file("res://scenes/fine_tune.tscn")
+    await create_timer(0.1).timeout
+    print("Application started and idled")
+    quit(0)

--- a/src/tests/test_load_examples.gd
+++ b/src/tests/test_load_examples.gd
@@ -1,0 +1,20 @@
+extends SceneTree
+
+const EXAMPLES := [
+    "res://tests/test_projects/simple_project.json",
+    "res://tests/test_projects/function_project.json"
+]
+
+func _init():
+    call_deferred("_run")
+
+func _run():
+    for f in EXAMPLES:
+        var text := FileAccess.get_file_as_string(f)
+        var parsed = JSON.parse_string(text)
+        if typeof(parsed) != TYPE_DICTIONARY:
+            push_error("Failed to load %s" % f)
+            quit(1)
+            return
+    print("Example projects loaded")
+    quit(0)

--- a/src/tests/test_projects/function_project.json
+++ b/src/tests/test_projects/function_project.json
@@ -1,0 +1,18 @@
+{
+  "functions": [
+    {
+      "name": "get_age",
+      "description": "Return user age",
+      "parameters": [
+        {"type": "Integer", "name": "age", "description": "Age", "isRequired": true}
+      ]
+    }
+  ],
+  "conversations": {
+    "C1": [
+      {"role": "user", "type": "Text", "textContent": "How old am I?"},
+      {"role": "assistant", "type": "Function Call", "functionName": "get_age", "functionParameters": [{"name": "age", "isUsed": true, "parameterValueNumber": 30, "parameterValueText": "", "parameterValueChoice": ""}], "functionResults": "30", "functionUsePreText": ""}
+    ]
+  },
+  "settings": {}
+}

--- a/src/tests/test_projects/simple_project.json
+++ b/src/tests/test_projects/simple_project.json
@@ -1,0 +1,13 @@
+{
+  "functions": [],
+  "conversations": {
+    "C1": [
+      {"role": "system", "type": "Text", "textContent": "Hello"},
+      {"role": "user", "type": "Text", "textContent": "Hi there"}
+    ]
+  },
+  "settings": {
+    "useGlobalSystemMessage": false,
+    "globalSystemMessage": ""
+  }
+}


### PR DESCRIPTION
## Summary
- add tests to ensure the application can start and idle
- add tests to load example fine-tuning files
- include simple example fine-tuning JSON files
- run all tests in CI
- move example fine-tuning projects into dedicated subfolder

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_6859cecadb048320a4d639bd73a7910b