### PR TITLE
Update tests to load repo examples

### DIFF
--- a/src/tests/test_load_examples.gd
+++ b/src/tests/test_load_examples.gd
@@ -1,20 +1,29 @@
 extends SceneTree
 
-const EXAMPLES := [
-    "res://tests/test_projects/simple_project.json",
-    "res://tests/test_projects/function_project.json"
-]
+const EXAMPLE_DIR := "res://../examples"
 
 func _init():
     call_deferred("_run")
 
 func _run():
-    for f in EXAMPLES:
-        var text := FileAccess.get_file_as_string(f)
-        var parsed = JSON.parse_string(text)
-        if typeof(parsed) != TYPE_DICTIONARY:
-            push_error("Failed to load %s" % f)
-            quit(1)
-            return
+    var dir = DirAccess.open(EXAMPLE_DIR)
+    if dir == null:
+        push_error("Failed to open examples directory")
+        quit(1)
+        return
+    dir.list_dir_begin()
+    var file := dir.get_next()
+    while file != "":
+        if not dir.current_is_dir() and file.get_extension().to_lower() == "json":
+            var path := "%s/%s" % [EXAMPLE_DIR, file]
+            var text := FileAccess.get_file_as_string(path)
+            var parsed = JSON.parse_string(text)
+            if typeof(parsed) != TYPE_DICTIONARY:
+                push_error("Failed to load %s" % path)
+                quit(1)
+                dir.list_dir_end()
+                return
+        file = dir.get_next()
+    dir.list_dir_end()
     print("Example projects loaded")
     quit(0)


### PR DESCRIPTION
## Summary
- load example project files from the `examples` folder instead of `tests/test_projects`

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_6859d744b5e4832097cd698376d3043d