### PR TITLE
Support drag-drop for projects and OpenAI message files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ You can also provide the program with your OpenAI API key and it can generate re
 - `Ctrl` + `Left Click` - Enlarge Image (when hovering image)
 - `Crtl` + `Right Click` - Smallen Image (when hovering image)
 - `Ctrl` + `Space` - Add new message
+- Drag and drop a `.ftproj` or `.json` file onto the window to load a project or
+  insert messages

--- a/src/scenes/messages_list.gd
+++ b/src/scenes/messages_list.gd
@@ -377,6 +377,21 @@ func on_dropped_files(files):
 				}
 			)
 			MessageInstance._on_file_dialog_file_selected(file)
+		elif file.to_lower().ends_with(".ftproj") or file.to_lower().ends_with(".json"):
+				var ft_node = get_tree().get_root().get_node("FineTune")
+				if file.to_lower().ends_with(".ftproj"):
+					ft_node.load_from_binary(file)
+					ft_node.RUNTIME["filepath"] = file
+				else:
+					var json_text = FileAccess.get_file_as_string(file)
+					var parsed = JSON.parse_string(json_text)
+					if parsed is Dictionary and parsed.has("functions") and parsed.has("conversations") and parsed.has("settings"):
+						ft_node.load_from_json_data(json_text)
+						ft_node.RUNTIME["filepath"] = file
+					else:
+						var ftcmsglist = ft_node.conversation_from_openai_message_json(json_text)
+						for ftmsg in ftcmsglist:
+							add_message(ftmsg)
 
 func add_message(message_obj):
 			# Add a new message to the MessagesListContainer


### PR DESCRIPTION
## Summary
- load `.ftproj` or `.json` by dropping files on the viewport
- insert dropped OpenAI message JSON into the current chat
- document new drag-and-drop ability in the README

## Testing
- `godot --headless --path . --script tests/test_application_start.gd`
- `godot --headless --path . --script tests/openai_import_test.gd`
- `godot --headless --path . --script tests/test_import_openai.gd`
- `godot --headless --path . --script tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_6869511ca1f0832098fa9cd276d469d0