### PR TITLE
Add optional image upload server support

### DIFF
--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -21,8 +21,10 @@ func to_var():
 	me["finetuneType"] = $VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.selected
 	me["exportImagesHow"] = $VBoxContainer/ExportImagesHowContainer/ExportImagesHowOptionButton.selected
 	me["useUserNames"] = $VBoxContainer/UseUserNamesCheckbox.button_pressed
-	me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
-	me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
+        me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
+        me["imageUploadServerURL"] = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
+        me["imageUploadServerKey"] = $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text
+        me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
 	me["tokenCounterPath"] = $VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.text
 	me["exportConvos"] = $VBoxContainer/ExportWhatConvoContainer/ExportWhatConvosOptionButton.selected
 	me["countTokensWhen"] = $VBoxContainer/TokenCountWhenContainer/TokenCounterWhenOptionButton.selected
@@ -47,8 +49,10 @@ func from_var(me):
 		if ($VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.get_item_text(i) == me["modelChoice"]):
 			$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.select(i)
 	$VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.select(me.get("finetuneType", 0))
-	$VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
-	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
+        $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
+        $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text = me.get("imageUploadServerURL", "")
+        $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text = me.get("imageUploadServerKey", "")
+        $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
 	_on_schema_content_editor_text_changed()
 	$VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.text = me.get("tokenCounterPath", "")
 	$VBoxContainer/ExportWhatConvoContainer/ExportWhatConvosOptionButton.selected = me.get("exportConvos", 0)

--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -21,10 +21,10 @@ func to_var():
 	me["finetuneType"] = $VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.selected
 	me["exportImagesHow"] = $VBoxContainer/ExportImagesHowContainer/ExportImagesHowOptionButton.selected
 	me["useUserNames"] = $VBoxContainer/UseUserNamesCheckbox.button_pressed
-        me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
-        me["imageUploadServerURL"] = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
-        me["imageUploadServerKey"] = $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text
-        me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
+	me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
+	me["imageUploadServerURL"] = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
+	me["imageUploadServerKey"] = $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text
+	me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
 	me["tokenCounterPath"] = $VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.text
 	me["exportConvos"] = $VBoxContainer/ExportWhatConvoContainer/ExportWhatConvosOptionButton.selected
 	me["countTokensWhen"] = $VBoxContainer/TokenCountWhenContainer/TokenCounterWhenOptionButton.selected
@@ -49,10 +49,10 @@ func from_var(me):
 		if ($VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.get_item_text(i) == me["modelChoice"]):
 			$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.select(i)
 	$VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.select(me.get("finetuneType", 0))
-        $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
-        $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text = me.get("imageUploadServerURL", "")
-        $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text = me.get("imageUploadServerKey", "")
-        $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
+	$VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
+	$VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text = me.get("imageUploadServerURL", "")
+	$VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text = me.get("imageUploadServerKey", "")
+	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
 	_on_schema_content_editor_text_changed()
 	$VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.text = me.get("tokenCounterPath", "")
 	$VBoxContainer/ExportWhatConvoContainer/ExportWhatConvosOptionButton.selected = me.get("exportConvos", 0)

--- a/src/scenes/conversation_settings.tscn
+++ b/src/scenes/conversation_settings.tscn
@@ -443,6 +443,41 @@ layout_mode = 2
 text = "GENERIC_CHECK"
 icon = ExtResource("3_swtgl")
 
+[node name="ImageUploadServerURLContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ImageUploadServerURLLabel" type="Label" parent="VBoxContainer/ImageUploadServerURLContainer"]
+layout_mode = 2
+text = "SETTINGS_IMAGE_UPLOAD_URL_LABEL"
+
+[node name="ImageUploadServerURLHint" type="TextureRect" parent="VBoxContainer/ImageUploadServerURLContainer"]
+layout_mode = 2
+tooltip_text = "SETTINGS_IMAGE_UPLOAD_URL_HINT"
+texture = ExtResource("3_kcvkw")
+expand_mode = 2
+
+[node name="ImageUploadServerURLEdit" type="LineEdit" parent="VBoxContainer/ImageUploadServerURLContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ImageUploadServerKeyContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ImageUploadServerKeyLabel" type="Label" parent="VBoxContainer/ImageUploadServerKeyContainer"]
+layout_mode = 2
+text = "SETTINGS_IMAGE_UPLOAD_KEY_LABEL"
+
+[node name="ImageUploadServerKeyHint" type="TextureRect" parent="VBoxContainer/ImageUploadServerKeyContainer"]
+layout_mode = 2
+tooltip_text = "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
+texture = ExtResource("3_kcvkw")
+expand_mode = 2
+
+[node name="ImageUploadServerKeyEdit" type="LineEdit" parent="VBoxContainer/ImageUploadServerKeyContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+secret = true
+
 [node name="SchemaContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
@@ -494,3 +529,5 @@ use_native_dialog = true
 [connection signal="pressed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentLoadFromFileBtn" to="." method="_on_schema_content_load_from_file_btn_pressed"]
 [connection signal="text_changed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor" to="." method="_on_schema_content_editor_text_changed"]
 [connection signal="file_selected" from="VBoxContainer/SchemaContainer/LoadSchemaFileDialog" to="." method="_on_load_schema_file_dialog_file_selected"]
+[connection signal="text_changed" from="VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit" to="." method="update_settings_global"]
+[connection signal="text_changed" from="VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit" to="." method="update_settings_global"]

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -6,6 +6,7 @@ extends HBoxContainer
 var image_access_web = FileAccessWeb.new()
 var token = "" # The token for the schema editor for this message
 var edit_message_url = ""
+var last_base64_to_upload = ""
 
 func selectionStringToIndex(node, string):
 	# takes a node (OptionButton) and a String that is one of the options and returns its index
@@ -227,10 +228,27 @@ func _on_file_dialog_file_selected(path: String) -> void:
 	var image_texture = ImageTexture.new()
 	image_texture.set_image(image)
 	
-	get_node("ImageMessageContainer/TextureRect").texture = image_texture
-	var bin = FileAccess.get_file_as_bytes(image_path)
-	var base_64_data = Marshalls.raw_to_base64(bin)
-	$ImageMessageContainer/Base64ImageEdit.text = base_64_data
+        get_node("ImageMessageContainer/TextureRect").texture = image_texture
+        var bin = FileAccess.get_file_as_bytes(image_path)
+        var base_64_data = Marshalls.raw_to_base64(bin)
+        var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
+        var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
+        last_base64_to_upload = base_64_data
+        if upload_url != "":
+                var http = HTTPRequest.new()
+                add_child(http)
+                http.request_completed.connect(self._on_image_upload_request_completed.bind(http))
+                var headers := PackedStringArray()
+                headers.append("Content-Type: application/json")
+                var ext = "jpg"
+                if image_path.to_lower().ends_with(".png"):
+                        ext = "png"
+                var payload = {"key": upload_key, "image": base_64_data, "ext": ext}
+                var err = http.request(upload_url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
+                if err != OK:
+                        $ImageMessageContainer/Base64ImageEdit.text = base_64_data
+                return
+        $ImageMessageContainer/Base64ImageEdit.text = base_64_data
 
 func base64_to_image(textureRectNode, b64Data):
 	var img = Image.new()
@@ -446,8 +464,15 @@ func _image_http_request_completed(result, response_code, headers, body):
 		$ImageMessageContainer/TextureRect.texture = load("res://icons/image-remove-custom.png")
 
 
-	var texture = ImageTexture.create_from_image(image)
-	$ImageMessageContainer/TextureRect.texture = texture
+        var texture = ImageTexture.create_from_image(image)
+        $ImageMessageContainer/TextureRect.texture = texture
+
+func _on_image_upload_request_completed(result, response_code, headers, body, request):
+        request.queue_free()
+        if response_code == 200:
+                $ImageMessageContainer/Base64ImageEdit.text = body.get_string_from_utf8().strip_edges()
+        else:
+                $ImageMessageContainer/Base64ImageEdit.text = last_base64_to_upload
 	
 func isImageURL(url: String) -> bool:
 	# Return false if the URL is empty or only whitespace.

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -228,27 +228,27 @@ func _on_file_dialog_file_selected(path: String) -> void:
 	var image_texture = ImageTexture.new()
 	image_texture.set_image(image)
 	
-        get_node("ImageMessageContainer/TextureRect").texture = image_texture
-        var bin = FileAccess.get_file_as_bytes(image_path)
-        var base_64_data = Marshalls.raw_to_base64(bin)
-        var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
-        var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
-        last_base64_to_upload = base_64_data
-        if upload_url != "":
-                var http = HTTPRequest.new()
-                add_child(http)
-                http.request_completed.connect(self._on_image_upload_request_completed.bind(http))
-                var headers := PackedStringArray()
-                headers.append("Content-Type: application/json")
-                var ext = "jpg"
-                if image_path.to_lower().ends_with(".png"):
-                        ext = "png"
-                var payload = {"key": upload_key, "image": base_64_data, "ext": ext}
-                var err = http.request(upload_url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
-                if err != OK:
-                        $ImageMessageContainer/Base64ImageEdit.text = base_64_data
-                return
-        $ImageMessageContainer/Base64ImageEdit.text = base_64_data
+	get_node("ImageMessageContainer/TextureRect").texture = image_texture
+	var bin = FileAccess.get_file_as_bytes(image_path)
+	var base_64_data = Marshalls.raw_to_base64(bin)
+	var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
+	var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
+	last_base64_to_upload = base_64_data
+	if upload_url != "":
+		var http = HTTPRequest.new()
+		add_child(http)
+		http.request_completed.connect(self._on_image_upload_request_completed.bind(http))
+		var headers := PackedStringArray()
+		headers.append("Content-Type: application/json")
+		var ext = "jpg"
+		if image_path.to_lower().ends_with(".png"):
+			ext = "png"
+		var payload = {"key": upload_key, "image": base_64_data, "ext": ext}
+		var err = http.request(upload_url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
+		if err != OK:
+			$ImageMessageContainer/Base64ImageEdit.text = base_64_data
+		return
+	$ImageMessageContainer/Base64ImageEdit.text = base_64_data
 
 func base64_to_image(textureRectNode, b64Data):
 	var img = Image.new()
@@ -464,15 +464,15 @@ func _image_http_request_completed(result, response_code, headers, body):
 		$ImageMessageContainer/TextureRect.texture = load("res://icons/image-remove-custom.png")
 
 
-        var texture = ImageTexture.create_from_image(image)
-        $ImageMessageContainer/TextureRect.texture = texture
+	var texture = ImageTexture.create_from_image(image)
+	$ImageMessageContainer/TextureRect.texture = texture
 
 func _on_image_upload_request_completed(result, response_code, headers, body, request):
-        request.queue_free()
-        if response_code == 200:
-                $ImageMessageContainer/Base64ImageEdit.text = body.get_string_from_utf8().strip_edges()
-        else:
-                $ImageMessageContainer/Base64ImageEdit.text = last_base64_to_upload
+	request.queue_free()
+	if response_code == 200:
+		$ImageMessageContainer/Base64ImageEdit.text = body.get_string_from_utf8().strip_edges()
+	else:
+		$ImageMessageContainer/Base64ImageEdit.text = last_base64_to_upload
 	
 func isImageURL(url: String) -> bool:
 	# Return false if the URL is empty or only whitespace.

--- a/src/scenes/message.tscn
+++ b/src/scenes/message.tscn
@@ -211,6 +211,8 @@ text = "MESSAGES_LOAD_IMAGE_FROM_URL"
 
 [node name="LoadImageFromURLHTTPRequest" type="HTTPRequest" parent="ImageMessageContainer"]
 
+[node name="UploadImageHTTPRequest" type="HTTPRequest" parent="ImageMessageContainer"]
+
 [node name="HSeparator" type="HSeparator" parent="ImageMessageContainer"]
 layout_mode = 2
 
@@ -645,4 +647,5 @@ layout_mode = 2
 [connection signal="pressed" from="SchemaMessageContainer/SchemaMessagePolling/SchemaMessagePollingReopenBrowserBtn" to="." method="_on_schema_message_polling_reopen_browser_btn_pressed"]
 [connection signal="request_completed" from="SchemaMessageContainer/InitEditingRequestToken" to="." method="_on_init_editing_request_token_request_completed"]
 [connection signal="request_completed" from="SchemaMessageContainer/PollForCompletion" to="." method="_on_poll_for_completion_request_completed"]
+[connection signal="request_completed" from="ImageMessageContainer/UploadImageHTTPRequest" to="." method="_on_image_upload_request_completed"]
 [connection signal="timeout" from="SchemaMessageContainer/PollingTimer" to="." method="_on_polling_timer_timeout"]

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -479,6 +479,22 @@ msgid "GENERIC_CHECK"
 msgstr "Check"
 
 #: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_LABEL"
+msgstr "URL of the image upload server:"
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_HINT"
+msgstr "Endpoint of the PHP upload script used to store images."
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_LABEL"
+msgstr "Upload key:"
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
+msgstr "Secret key required by the upload server"
+
+#: scenes/conversation_settings.tscn
 msgid "SETTINGS_SCHEMA"
 msgstr "JSON schema:"
 

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -497,6 +497,22 @@ msgid "GENERIC_CHECK"
 msgstr "Prüfen"
 
 #: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_LABEL"
+msgstr "URL des Bild-Upload-Servers:"
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_HINT"
+msgstr "URL des kleinen Bild-Upload-PHP-Skripts."
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_LABEL"
+msgstr "Bild-Upload-Key:"
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
+msgstr "Geheimer Schlüssel, der vom Bild-Upload-Server verlangt wird."
+
+#: scenes/conversation_settings.tscn
 msgid "SETTINGS_SCHEMA"
 msgstr "JSON-Schema"
 

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -414,6 +414,22 @@ msgid "SETTINGS_SCHEMA_EDITOR_URL_HINT"
 msgstr ""
 
 #: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_LABEL"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_URL_HINT"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_LABEL"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
 msgid "GENERIC_CHECK"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- allow images to be uploaded to a server instead of being stored as base64
- support server URL and key in conversation settings UI
- integrate upload into message script
- provide example PHP upload server implementation
- update translations

## Testing
- `php -l scripts/image-upload-server.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdf974de88320a8e9701b744b8720