### PR TITLE
Remember last project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ You can also provide the program with your OpenAI API key and it can generate re
 - `Ctrl` + `Left Click` - Enlarge Image (when hovering image)
 - `Crtl` + `Right Click` - Smallen Image (when hovering image)
 - `Ctrl` + `Space` - Add new message
-- Drag and drop a `.ftproj` or `.json` file onto the window to load a project or
-  insert messages
+- Drag and drop a `.ftproj` or `.json` file onto the window to load a project or insert messages
+- The application remembers the last opened project file and loads it automatically on the next start if it still exists

--- a/src/scenes/messages_list.gd
+++ b/src/scenes/messages_list.gd
@@ -382,12 +382,14 @@ func on_dropped_files(files):
 				if file.to_lower().ends_with(".ftproj"):
 					ft_node.load_from_binary(file)
 					ft_node.RUNTIME["filepath"] = file
+					ft_node.save_last_project_path(file)
 				else:
 					var json_text = FileAccess.get_file_as_string(file)
 					var parsed = JSON.parse_string(json_text)
 					if parsed is Dictionary and parsed.has("functions") and parsed.has("conversations") and parsed.has("settings"):
 						ft_node.load_from_json_data(json_text)
 						ft_node.RUNTIME["filepath"] = file
+						ft_node.save_last_project_path(file)
 					else:
 						var ftcmsglist = ft_node.conversation_from_openai_message_json(json_text)
 						for ftmsg in ftcmsglist:


### PR DESCRIPTION
## Summary
- keep the last opened project path in `user://last_project.txt`
- save/load project data for web exports
- automatically load the previous project on start
- remember dragged-in projects as well
- document new behaviour
- fix indentation of newly added code

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_687039ca3d1c8320b99d0525499efa04