### PR TITLE
Translate conversation tabs

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -109,7 +109,11 @@ func _ready() -> void:
 	file_access_web.loaded.connect(_on_file_loaded)
 	file_access_web.progress.connect(_on_upload_progress)
 	load_last_project_on_start()
-	
+
+	var tab_bar := $Conversation.get_tab_bar()
+	tab_bar.set_tab_title(0, tr("Messages"))
+	tab_bar.set_tab_title(1, tr("Functions"))
+	tab_bar.set_tab_title(2, tr("Settings"))
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -73,15 +73,15 @@ msgstr "Delete Function"
 
 #: scenes/conversation.tscn
 msgid "Messages"
-msgstr ""
+msgstr "Messages"
 
 #: scenes/conversation.tscn
 msgid "Functions"
-msgstr ""
+msgstr "Functions"
 
 #: scenes/conversation.tscn
 msgid "Settings"
-msgstr ""
+msgstr "Settings"
 
 #: scenes/conversation_settings.tscn
 msgid "SETTINGS_USE_GLOBAL_SYSTEM_MESSAGE"

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -73,15 +73,15 @@ msgstr "Funktion löschen"
 
 #: scenes/conversation.tscn
 msgid "Messages"
-msgstr "Messages"
+msgstr "Nachrichten"
 
 #: scenes/conversation.tscn
 msgid "Functions"
-msgstr "Functions"
+msgstr "Funktionen"
 
 #: scenes/conversation.tscn
 msgid "Settings"
-msgstr "Settings"
+msgstr "Einstellungen"
 
 #: scenes/conversation_settings.tscn
 msgid "SETTINGS_USE_GLOBAL_SYSTEM_MESSAGE"


### PR DESCRIPTION
## Summary
- translate conversation tabs using `set_tab_title`
- add tab titles to English and German translation files
- fix indentation in `_ready()`

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_6870427511288320abc52fa0dd6f1003