### PR TITLE
Fix base64 export for JPEG images

### DIFF
--- a/src/addons/openai_api/Scripts/Message.gd
+++ b/src/addons/openai_api/Scripts/Message.gd
@@ -165,8 +165,8 @@ func isImageURL(url: String) -> bool:
 	# Remove any query parameters or fragment identifiers.
 	var cleaned_url = lower_url.split("?")[0].split("#")[0]
 
-	# Finally, check if the cleaned URL ends with a valid image extension.
-	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg")
+        # Finally, check if the cleaned URL ends with a valid image extension.
+	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg") or cleaned_url.ends_with(".jpeg")
 
 # This function uses the above isJpgOrPngURL() to check if the URL is valid,
 # and if so, returns "png" if the URL ends with .png or "jpg" if it ends with .jpg.
@@ -184,5 +184,7 @@ func getImageType(url: String) -> String:
 		return "png"
 	elif base_url.ends_with(".jpg"):
 		return "jpg"
+	elif base_url.ends_with(".jpeg"):
+		return "jpeg"
 	else:
 		return ""

--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -510,7 +510,7 @@ func isImageURL(url: String) -> bool:
 	var cleaned_url = lower_url.split("?")[0].split("#")[0]
 
 	# Finally, check if the cleaned URL ends with a valid image extension.
-	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg")
+	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg") or cleaned_url.ends_with(".jpeg")
 
 # This function uses the above isJpgOrPngURL() to check if the URL is valid,
 # and if so, returns "png" if the URL ends with .png or "jpg" if it ends with .jpg.
@@ -528,5 +528,7 @@ func getImageType(url: String) -> String:
 		return "png"
 	elif base_url.ends_with(".jpg"):
 		return "jpg"
+	elif base_url.ends_with(".jpeg"):
+		return "jpeg"
 	else:
 		return ""

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -671,7 +671,7 @@ func isImageURL(url: String) -> bool:
 	var cleaned_url = lower_url.split("?")[0].split("#")[0]
 
 	# Finally, check if the cleaned URL ends with a valid image extension.
-	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg")
+	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg") or cleaned_url.ends_with(".jpeg")
 
 # This function uses the above isJpgOrPngURL() to check if the URL is valid,
 # and if so, returns "png" if the URL ends with .png or "jpg" if it ends with .jpg.
@@ -689,6 +689,8 @@ func getImageType(url: String) -> String:
 		return "png"
 	elif base_url.ends_with(".jpg"):
 		return "jpg"
+	elif base_url.ends_with(".jpeg"):
+		return "jpeg"
 	else:
 		return ""
 

--- a/src/scenes/messages_list.gd
+++ b/src/scenes/messages_list.gd
@@ -337,7 +337,7 @@ func isImageURL(url: String) -> bool:
 	var cleaned_url = lower_url.split("?")[0].split("#")[0]
 
 	# Finally, check if the cleaned URL ends with a valid image extension.
-	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg")
+	return cleaned_url.ends_with(".png") or cleaned_url.ends_with(".jpg") or cleaned_url.ends_with(".jpeg")
 
 # This function uses the above isJpgOrPngURL() to check if the URL is valid,
 # and if so, returns "png" if the URL ends with .png or "jpg" if it ends with .jpg.
@@ -355,6 +355,8 @@ func getImageType(url: String) -> String:
 		return "png"
 	elif base_url.ends_with(".jpg"):
 		return "jpg"
+	elif base_url.ends_with(".jpeg"):
+		return "jpeg"
 	else:
 		return ""
 		

--- a/src/tests/test_import_openai.gd
+++ b/src/tests/test_import_openai.gd
@@ -69,6 +69,8 @@ func test_image_utils():
     assert_eq(ex.isImageURL("http://example.com/img.png"), true, "isImageURL valid")
     assert_eq(ex.isImageURL("invalid"), false, "isImageURL invalid")
     assert_eq(ex.getImageType("https://example.com/pic.jpg?x=1"), "jpg", "getImageType jpg")
+    assert_eq(ex.isImageURL("https://example.com/pic.jpeg"), true, "isImageURL jpeg")
+    assert_eq(ex.getImageType("https://example.com/pic.jpeg"), "jpeg", "getImageType jpeg")
 
 func test_convert_text_message():
     var Exporter = load("res://scenes/exporter.gd")


### PR DESCRIPTION
## Summary
- add `.jpeg` support in image utilities
- update tests for JPEG handling

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_6872599ccbf88320993a2dd633a28604