### PR TITLE
Fix base64 detection for image URLs

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -124,35 +124,35 @@ func convert_message_to_openai_format(message, function_map=null):
 		return toAddDict
 	# Image message
 	elif message['type'] == 'Image':
-                var image_url_data = ""
-                var image_content = message['imageContent']
-                var begins_with_http = image_content.begins_with("http://") or image_content.begins_with("https://")
+		var image_url_data = ""
+		var image_content = message['imageContent']
+		var begins_with_http = image_content.begins_with("http://") or image_content.begins_with("https://")
 
-                if getSettings().get('exportImagesHow', 0) == 0:
-                        if isImageURL(image_content):
-                                image_url_data = image_content
-                        elif begins_with_http:
-                                var base64_data = await url_to_base64(image_content)
-                                var ext = get_ext_from_base64(base64_data)
-                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
-                        else:
-                                var ext = get_ext_from_base64(image_content)
-                                image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
-                elif getSettings().get('exportImagesHow', 0) == 1:
-                        if isImageURL(image_content):
-                                var base64_data = await url_to_base64(image_content)
-                                var ext = getImageType(image_content)
-                                if ext == "":
-                                        push_error("Invalid file type")
-                                        ext = "jpeg"
-                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
-                        elif begins_with_http:
-                                var base64_data = await url_to_base64(image_content)
-                                var ext = get_ext_from_base64(base64_data)
-                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
-                        else:
-                                var ext = get_ext_from_base64(image_content)
-                                image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
+		if getSettings().get('exportImagesHow', 0) == 0:
+			if isImageURL(image_content):
+				image_url_data = image_content
+			elif begins_with_http:
+				var base64_data = await url_to_base64(image_content)
+				var ext = get_ext_from_base64(base64_data)
+				image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+			else:
+				var ext = get_ext_from_base64(image_content)
+				image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
+		elif getSettings().get('exportImagesHow', 0) == 1:
+			if isImageURL(image_content):
+				var base64_data = await url_to_base64(image_content)
+				var ext = getImageType(image_content)
+				if ext == "":
+					push_error("Invalid file type")
+					ext = "jpeg"
+				image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+			elif begins_with_http:
+				var base64_data = await url_to_base64(image_content)
+				var ext = get_ext_from_base64(base64_data)
+				image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+			else:
+				var ext = get_ext_from_base64(image_content)
+				image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
 		return {
 			'role': message['role'],
 			'content': [

--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -124,25 +124,35 @@ func convert_message_to_openai_format(message, function_map=null):
 		return toAddDict
 	# Image message
 	elif message['type'] == 'Image':
-		var image_url_data = ""
-		var image_content = message['imageContent']
-		if getSettings().get('exportImagesHow', 0) == 0:
-			if isImageURL(image_content):
-				image_url_data = image_content
-			else:
-				var ext = get_ext_from_base64(image_content)
-				image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
-		elif getSettings().get('exportImagesHow', 0) == 1:
-			if isImageURL(image_content):
-				var base64_data = await url_to_base64(image_content)
-				var ext = getImageType(image_content)
-				if ext == "":
-					push_error("Invalid file type")
-					ext = "jpeg"
-				image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
-			else:
-				var ext = get_ext_from_base64(image_content)
-				image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
+                var image_url_data = ""
+                var image_content = message['imageContent']
+                var begins_with_http = image_content.begins_with("http://") or image_content.begins_with("https://")
+
+                if getSettings().get('exportImagesHow', 0) == 0:
+                        if isImageURL(image_content):
+                                image_url_data = image_content
+                        elif begins_with_http:
+                                var base64_data = await url_to_base64(image_content)
+                                var ext = get_ext_from_base64(base64_data)
+                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+                        else:
+                                var ext = get_ext_from_base64(image_content)
+                                image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
+                elif getSettings().get('exportImagesHow', 0) == 1:
+                        if isImageURL(image_content):
+                                var base64_data = await url_to_base64(image_content)
+                                var ext = getImageType(image_content)
+                                if ext == "":
+                                        push_error("Invalid file type")
+                                        ext = "jpeg"
+                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+                        elif begins_with_http:
+                                var base64_data = await url_to_base64(image_content)
+                                var ext = get_ext_from_base64(base64_data)
+                                image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
+                        else:
+                                var ext = get_ext_from_base64(image_content)
+                                image_url_data = "data:image/%s;base64,%s" % [ext, image_content]
 		return {
 			'role': message['role'],
 			'content': [

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -717,15 +717,15 @@ func get_ext_from_base64(b64: String) -> String:
 	return "jpg"
 
 func _upload_base64_image_get_url(b64: String, upload_url: String, upload_key: String) -> String:
-        var data_str = b64
-        if data_str.begins_with("http://") or data_str.begins_with("https://"):
-                data_str = await url_to_base64(data_str)
-        var http = HTTPRequest.new()
-        add_child(http)
-        var headers := PackedStringArray()
-        headers.append("Content-Type: application/json")
-        var ext = get_ext_from_base64(data_str)
-        var payload = {"key": upload_key, "image": data_str, "ext": ext}
+	var data_str = b64
+	if data_str.begins_with("http://") or data_str.begins_with("https://"):
+		data_str = await url_to_base64(data_str)
+	var http = HTTPRequest.new()
+	add_child(http)
+	var headers := PackedStringArray()
+	headers.append("Content-Type: application/json")
+	var ext = get_ext_from_base64(data_str)
+	var payload = {"key": upload_key, "image": data_str, "ext": ext}
 	var err = http.request(upload_url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
 	if err != OK:
 		http.queue_free()

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -717,12 +717,15 @@ func get_ext_from_base64(b64: String) -> String:
 	return "jpg"
 
 func _upload_base64_image_get_url(b64: String, upload_url: String, upload_key: String) -> String:
-	var http = HTTPRequest.new()
-	add_child(http)
-	var headers := PackedStringArray()
-	headers.append("Content-Type: application/json")
-	var ext = get_ext_from_base64(b64)
-	var payload = {"key": upload_key, "image": b64, "ext": ext}
+        var data_str = b64
+        if data_str.begins_with("http://") or data_str.begins_with("https://"):
+                data_str = await url_to_base64(data_str)
+        var http = HTTPRequest.new()
+        add_child(http)
+        var headers := PackedStringArray()
+        headers.append("Content-Type: application/json")
+        var ext = get_ext_from_base64(data_str)
+        var payload = {"key": upload_key, "image": data_str, "ext": ext}
 	var err = http.request(upload_url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
 	if err != OK:
 		http.queue_free()

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -278,12 +278,12 @@ func get_ext_from_base64(b64:String) -> String:
 	return "jpg"
 
 func maybe_upload_base64_image():
-	var img_data = $ImageMessageContainer/Base64ImageEdit.text
-	if img_data == "" or isImageURL(img_data):
-		return
-	var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
-	var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
-	var upload_enabled = get_node("/root/FineTune").SETTINGS.get("imageUploadSetting", 0)
+        var img_data = $ImageMessageContainer/Base64ImageEdit.text
+        if img_data == "" or isImageURL(img_data) or img_data.begins_with("http://") or img_data.begins_with("https://"):
+                return
+        var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
+        var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
+        var upload_enabled = get_node("/root/FineTune").SETTINGS.get("imageUploadSetting", 0)
 	if upload_enabled == 1 and upload_url != "" and upload_key != "":
 		last_base64_to_upload = img_data
 		var http = HTTPRequest.new()

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -278,12 +278,12 @@ func get_ext_from_base64(b64:String) -> String:
 	return "jpg"
 
 func maybe_upload_base64_image():
-        var img_data = $ImageMessageContainer/Base64ImageEdit.text
-        if img_data == "" or isImageURL(img_data) or img_data.begins_with("http://") or img_data.begins_with("https://"):
-                return
-        var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
-        var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
-        var upload_enabled = get_node("/root/FineTune").SETTINGS.get("imageUploadSetting", 0)
+	var img_data = $ImageMessageContainer/Base64ImageEdit.text
+	if img_data == "" or isImageURL(img_data) or img_data.begins_with("http://") or img_data.begins_with("https://"):
+		return
+	var upload_url = get_node("/root/FineTune").SETTINGS.get("imageUploadServerURL", "")
+	var upload_key = get_node("/root/FineTune").SETTINGS.get("imageUploadServerKey", "")
+	var upload_enabled = get_node("/root/FineTune").SETTINGS.get("imageUploadSetting", 0)
 	if upload_enabled == 1 and upload_url != "" and upload_key != "":
 		last_base64_to_upload = img_data
 		var http = HTTPRequest.new()


### PR DESCRIPTION
## Summary
- handle http(s) URLs when converting messages for export
- fetch base64 if `_upload_base64_image_get_url` receives a URL
- avoid uploading if message text contains an URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68750dbdbd00832096d97a20e2786a0a