### PR TITLE
Add workflow to auto-update OpenAI plugin

### DIFF
--- a/.github/workflows/update_openai_plugin.yml
+++ b/.github/workflows/update_openai_plugin.yml
@@ -1,0 +1,46 @@
+name: Update OpenAI Plugin
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  update-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout OpenAi-Godot source
+        uses: actions/checkout@v3
+        with:
+          repository: wielandb/OpenAi-Godot
+          path: openai-source
+
+      - name: Sync plugin
+        run: |
+          rm -rf src/addons/openai_api
+          cp -r openai-source/addons/openai_api src/addons/openai_api
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add src/addons/openai_api
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update OpenAI plugin"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update OpenAI plugin
+          branch: bot/update-openai-plugin
+          title: Update OpenAI plugin
+          body: Automated update of OpenAI plugin from OpenAi-Godot repository.
+          delete-branch: true
+          signoff: false


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Action to sync the OpenAI plugin from `wielandb/OpenAi-Godot`

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_687ba6306960832084d4c20719418bdd