### PR TITLE
Fix permissions for update workflow

### DIFF
--- a/.github/workflows/update_openai_plugin.yml
+++ b/.github/workflows/update_openai_plugin.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-plugin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix missing token permissions so the workflow can push

## Testing
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_687ba9479e588320a039edfa9a253a4c