### PR TITLE
Add grader creation functionality

### DIFF
--- a/src/grader_container.gd
+++ b/src/grader_container.gd
@@ -1,0 +1,20 @@
+extends VBoxContainer
+
+@onready var GRADER_SCENES = [
+	preload("res://scenes/graders/string_check_grader.tscn"),
+	preload("res://scenes/graders/string_similarity_grader.tscn"),
+	preload("res://scenes/graders/score_model_grader.tscn"),
+	preload("res://label_model_grader.tscn"),
+	preload("res://scenes/graders/python_grader.tscn")
+]
+
+func _ready() -> void:
+	$GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.connect("item_selected", self, "_on_grader_type_option_button_item_selected")
+	_on_grader_type_option_button_item_selected($GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.selected)
+
+func _on_grader_type_option_button_item_selected(index: int) -> void:
+	for child in $ActualGraderContainer.get_children():
+	    child.queue_free()
+	if index >= 0 and index < GRADER_SCENES.size():
+	    var inst = GRADER_SCENES[index].instantiate()
+	    $ActualGraderContainer.add_child(inst)

--- a/src/grader_container.tscn
+++ b/src/grader_container.tscn
@@ -1,11 +1,14 @@
 [gd_scene format=3 uid="uid://bxjaykkfeey4u"]
 
+[ext_resource type="Script" path="res://grader_container.gd" id="1_grdc"]
+
 [node name="GraderContainer" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_grdc")
 
 [node name="GraderHeaderMarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -36,6 +39,8 @@ popup/item_3/text = "Label Model Grader"
 popup/item_3/id = 3
 popup/item_4/text = "Python Grader"
 popup/item_4/id = 4
+
+[connection signal="item_selected" from="GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton" to="." method="_on_grader_type_option_button_item_selected"]
 
 [node name="ActualGraderContainer" type="VBoxContainer" parent="."]
 layout_mode = 2

--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -1,1 +1,9 @@
 extends ScrollContainer
+
+@onready var GRADER_SCENE = preload("res://grader_container.tscn")
+
+func _on_add_grader_button_pressed() -> void:
+	var inst = GRADER_SCENE.instantiate()
+	$GradersListContainer.add_child(inst)
+	$GradersListContainer.move_child($GradersListContainer/AddGraderButton, -1)
+

--- a/src/scenes/graders/graders_list.tscn
+++ b/src/scenes/graders/graders_list.tscn
@@ -20,3 +20,5 @@ size_flags_vertical = 3
 [node name="AddGraderButton" type="Button" parent="GradersListContainer"]
 layout_mode = 2
 text = "GRADERS_ADD_GRADER_BUTTON_TEXT"
+
+[connection signal="pressed" from="GradersListContainer/AddGraderButton" to="." method="_on_add_grader_button_pressed"]


### PR DESCRIPTION
## Summary
- hook up Add Grader button in the graders list
- create script for generic grader container
- spawn specific grader scenes when option button is changed
- connect UI nodes to new logic

## Testing
- `bash check_tabs.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f5556c9f48320ab1e1d6ffa9c009c