### PR TITLE
Fix grader container scene references

### DIFF
--- a/src/grader_name_container.tscn
+++ b/src/grader_name_container.tscn
@@ -1,4 +1,0 @@
-[gd_scene format=3 uid="uid://i05cns40c8dk"]
-
-[node name="NameContainer" type="HBoxContainer"]
-size_flags_vertical = 3

--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 	preload("res://scenes/graders/string_check_grader.tscn"),
 	preload("res://scenes/graders/string_similarity_grader.tscn"),
 	preload("res://scenes/graders/score_model_grader.tscn"),
-	preload("res://label_model_grader.tscn"),
+	preload("res://scenes/graders/label_model_grader.tscn"),
 	preload("res://scenes/graders/python_grader.tscn")
 ]
 

--- a/src/scenes/graders/grader_container.tscn
+++ b/src/scenes/graders/grader_container.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://bxjaykkfeey4u"]
 
-[ext_resource type="Script" path="res://grader_container.gd" id="1_grdc"]
+[ext_resource type="Script" path="res://scenes/graders/grader_container.gd" id="1_grdc"]
 
 [node name="GraderContainer" type="VBoxContainer"]
 anchors_preset = 15

--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -1,6 +1,6 @@
 extends ScrollContainer
 
-@onready var GRADER_SCENE = preload("res://grader_container.tscn")
+@onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
 
 func _on_add_grader_button_pressed() -> void:
 	var inst = GRADER_SCENE.instantiate()


### PR DESCRIPTION
## Summary
- fix `grader_container.tscn` script path
- update `grader_container.gd` scene preload path
- update `graders.gd` to reference moved scene
- remove stray duplicate scene file

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd && godot --headless --path src -s res://tests/test_application_start.gd && godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_687f5fdc9fac83208cd0979c56b542a2