### PR TITLE
Implement multi grader button functionality

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -1,0 +1,17 @@
+extends VBoxContainer
+
+@onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
+
+func _ready() -> void:
+	$MarginContainer/AddGraderAButton.connect("pressed", _on_add_grader_a_button_pressed)
+	$MarginContainer2/AddGraderBButton.connect("pressed", _on_add_grader_b_button_pressed)
+
+func _on_add_grader_a_button_pressed() -> void:
+	var inst = GRADER_SCENE.instantiate()
+	$MarginContainer.add_child(inst)
+	$MarginContainer/AddGraderAButton.queue_free()
+
+func _on_add_grader_b_button_pressed() -> void:
+	var inst = GRADER_SCENE.instantiate()
+	$MarginContainer2.add_child(inst)
+	$MarginContainer2/AddGraderBButton.queue_free()

--- a/src/scenes/graders/multi_grader.gd.uid
+++ b/src/scenes/graders/multi_grader.gd.uid
@@ -1,0 +1,1 @@
+uid://7yjd12ebkydr

--- a/src/scenes/graders/multi_grader.tscn
+++ b/src/scenes/graders/multi_grader.tscn
@@ -1,8 +1,10 @@
 [gd_scene load_steps=2 format=3 uid="uid://dqovavb6mlxs0"]
 
 [ext_resource type="Texture2D" uid="uid://d4h3rvxloygx4" path="res://icons/pen-plus-custom.png" id="1_j2kkp"]
+[ext_resource type="Script" uid="uid://7yjd12ebkydr" path="res://scenes/graders/multi_grader.gd" id="1_mulgr"]
 
 [node name="MultiGrader" type="VBoxContainer"]
+script = ExtResource("1_mulgr")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -42,3 +44,6 @@ text = "Score Formula:"
 [node name="ScoreFormulaEdit" type="LineEdit" parent="ScoreFormulaContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[connection signal="pressed" from="MarginContainer/AddGraderAButton" to="." method="_on_add_grader_a_button_pressed"]
+[connection signal="pressed" from="MarginContainer2/AddGraderBButton" to="." method="_on_add_grader_b_button_pressed"]


### PR DESCRIPTION
## Summary
- add multi_grader.gd script to spawn grader containers
- connect AddGrader buttons in multi_grader.tscn
- register script in multi_grader.tscn with unique uid

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_68853c5963b08320895c97418399eea9