### PR TITLE
Fix missing graders in MultiGrader

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -3,4 +3,7 @@ extends VBoxContainer
 @onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
 
 func _ready() -> void:
-	pass
+	if $MarginContainer.get_child_count() == 0:
+		$MarginContainer.add_child(GRADER_SCENE.instantiate())
+	if $MarginContainer2.get_child_count() == 0:
+		$MarginContainer2.add_child(GRADER_SCENE.instantiate())


### PR DESCRIPTION
## Summary
- ensure the MultiGrader node always creates two `GraderContainer` children

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_68868785c9ac8320905870fa2f1b8597