### PR TITLE
Implement label model grader improvements

### DIFF
--- a/src/scenes/graders/label_model_grader.gd
+++ b/src/scenes/graders/label_model_grader.gd
@@ -1,6 +1,13 @@
 extends VBoxContainer
 
-var passing_icon = preload("res://icons/check-decagram-custom.png")
+	var passing_icon = preload("res://icons/check-decagram-custom.png")
+var MESSAGE_SCENE = preload("res://scenes/message.tscn")
+
+func _ready() -> void:
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			msg._on_message_type_item_selected(msg.get_node("MessageSettingsContainer/MessageType").selected)
 
 func to_var():
 	var me = {}
@@ -32,3 +39,24 @@ func _on_labels_list_item_activated(index: int) -> void:
 	else:
 		$LabelsList.set_item_icon(index, passing_icon)
 	$LabelsList.deselect_all()
+
+func _on_labels_list_item_right_clicked(index: int) -> void:
+	$LabelsList.remove_item(index)
+
+func _on_new_label_button_pressed() -> void:
+	var text = $NewLabelsContainer/NewLabelLabel2.text
+	if text != "":
+		$LabelsList.add_item(text)
+		$NewLabelsContainer/NewLabelLabel2.text = ""
+		$LabelsList.deselect_all()
+
+func _on_add_message_button_pressed() -> void:
+	var container = MarginContainer.new()
+	container.layout_mode = 2
+	container.add_theme_constant_override("margin_left", 90)
+	container.add_theme_constant_override("margin_right", 95)
+	var msg = MESSAGE_SCENE.instantiate()
+	container.add_child(msg)
+	msg._on_message_type_item_selected(msg.get_node("MessageSettingsContainer/MessageType").selected)
+	$MessagesContainer.add_child(container)
+	$MessagesContainer.move_child($MessagesContainer/AddMessageButton, -1)

--- a/src/scenes/graders/label_model_grader.tscn
+++ b/src/scenes/graders/label_model_grader.tscn
@@ -40,6 +40,10 @@ theme_override_constants/margin_right = 95
 [node name="Message" parent="MessagesContainer/MarginContainer2" instance=ExtResource("1_ll3dp")]
 layout_mode = 2
 
+[node name="AddMessageButton" type="Button" parent="MessagesContainer"]
+layout_mode = 2
+text = "Add Message"
+
 [node name="NewLabelsContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
 
@@ -84,3 +88,6 @@ layout_mode = 2
 
 [connection signal="item_activated" from="LabelsList" to="." method="_on_labels_list_item_activated"]
 [connection signal="item_selected" from="LabelsList" to="." method="_on_labels_list_item_activated"]
+[connection signal="item_rmb_selected" from="LabelsList" to="." method="_on_labels_list_item_right_clicked"]
+[connection signal="pressed" from="MessagesContainer/AddMessageButton" to="." method="_on_add_message_button_pressed"]
+[connection signal="pressed" from="NewLabelsContainer/NewLabelButton" to="." method="_on_new_label_button_pressed"]


### PR DESCRIPTION
## Summary
- ensure message widgets show text fields when the grader loads
- allow adding messages via AddMessageButton
- allow adding/removing labels in label model grader
- wire up GUI signals for new interactions

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688bbd1eccac8320ad346b000dc16a67