### PR TITLE
Enable dynamic MultiGrader

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -3,7 +3,15 @@ extends VBoxContainer
 @onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
 
 func _ready() -> void:
-	if $MarginContainer.get_child_count() == 0:
-		$MarginContainer.add_child(GRADER_SCENE.instantiate())
-	if $MarginContainer2.get_child_count() == 0:
-		$MarginContainer2.add_child(GRADER_SCENE.instantiate())
+	pass
+
+func _on_add_grader_button_pressed() -> void:
+	var wrapper := MarginContainer.new()
+	wrapper.layout_mode = 2
+	wrapper.size_flags_vertical = 3
+	wrapper.add_theme_constant_override("margin_left", 50)
+	var inst := GRADER_SCENE.instantiate()
+	wrapper.add_child(inst)
+	inst.connect("tree_exited", Callable(wrapper, "queue_free"))
+	$GradersContainer.add_child(wrapper)
+	$GradersContainer.move_child($GradersContainer/AddGraderButton, -1)

--- a/src/scenes/graders/multi_grader.tscn
+++ b/src/scenes/graders/multi_grader.tscn
@@ -10,18 +10,18 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_mulgr")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+
+[node name="GradersContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/margin_left = 50
+
+[node name="AddGraderButton" type="Button" parent="GradersContainer"]
+layout_mode = 2
+text = "Add Grader"
 
 [node name="HSeparator" type="HSeparator" parent="."]
 layout_mode = 2
-
-[node name="MarginContainer2" type="MarginContainer" parent="."]
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_constants/margin_left = 50
 
 [node name="ScoreFormulaContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
@@ -33,3 +33,5 @@ text = "Score Formula:"
 [node name="ScoreFormulaEdit" type="LineEdit" parent="ScoreFormulaContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[connection signal="pressed" from="GradersContainer/AddGraderButton" to="." method="_on_add_grader_button_pressed"]


### PR DESCRIPTION
## Summary
- refactor `MultiGrader` scene to support a list of sub graders
- allow adding sub-graders wrapped in `MarginContainer` dynamically

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688bbfeb9dac8320a06957a4ecf03c7e