### PR TITLE
Fix MultiGrader scene preload

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 
-@onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
+const GRADER_SCENE := preload("res://scenes/graders/grader_container.tscn")
 
 func _ready() -> void:
 	pass


### PR DESCRIPTION
## Summary
- fix MultiGrader to preload grader scene as constant

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s tmp_script.gd` *(fails: Parse Error)*

------
https://chatgpt.com/codex/tasks/task_e_688bf3cb34ac832089605767a9737290