### PR TITLE
Fix MultiGrader resource path

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 
-const GRADER_SCENE := preload("res://scenes/graders/grader_container.tscn")
+@onready var GRADER_SCENE: PackedScene = load(get_script().resource_path.get_base_dir().path_join("grader_container.tscn"))
 
 func _ready() -> void:
 	pass


### PR DESCRIPTION
## Summary
- fix MultiGrader to load grader container relative to its script

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd && godot --headless --path src -s res://tests/test_application_start.gd && godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688d4eec68ec832093d7c909d855229c