### PR TITLE
Update grader container structure

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -14,12 +14,12 @@ func _ready() -> void:
 	_on_grader_type_option_button_item_selected($GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.selected)
 
 func _on_grader_type_option_button_item_selected(index: int) -> void:
-	for child in $ActualGraderContainer.get_children():
+	for child in $ActualGraderContainer/GraderMarginContainer.get_children():
 		child.queue_free()
 	if index >= 0 and index < GRADER_SCENES.size():
 		var inst = GRADER_SCENES[index].instantiate()
-		$ActualGraderContainer.add_child(inst)
-
+		$ActualGraderContainer/GraderMarginContainer.add_child(inst)
 
 func _on_delete_button_pressed() -> void:
 	queue_free()
+

--- a/src/scenes/graders/grader_container.tscn
+++ b/src/scenes/graders/grader_container.tscn
@@ -46,6 +46,12 @@ popup/item_5/id = 5
 layout_mode = 2
 size_flags_vertical = 3
 
+[node name="GraderMarginContainer" type="MarginContainer" parent="ActualGraderContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 50
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 50
+theme_override_constants/margin_bottom = 5
 [node name="GraderSettingsContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
 


### PR DESCRIPTION
## Summary
- wrap instantiated graders in a `GraderMarginContainer`
- adjust script to add graders inside the margin container
- fix indentation of the new line

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src --quit --script res://tests/test_application_start.gd` *(fails: resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d5325745083208bf67158d7367a0b