### PR TITLE
Implement debounced grader verification

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -9,8 +9,15 @@ extends VBoxContainer
 	preload("res://scenes/graders/multi_grader.tscn")
 ]
 
+var _verify_timer: Timer
+
 func _ready() -> void:
 	$GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.connect("item_selected", _on_grader_type_option_button_item_selected)
+	_verify_timer = Timer.new()
+	_verify_timer.one_shot = true
+	_verify_timer.wait_time = 2.0
+	add_child(_verify_timer)
+	_verify_timer.connect("timeout", Callable(self, "_on_verify_timeout"))
 	_on_grader_type_option_button_item_selected($GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.selected)
 
 func _on_grader_type_option_button_item_selected(index: int) -> void:
@@ -19,9 +26,32 @@ func _on_grader_type_option_button_item_selected(index: int) -> void:
 	if index >= 0 and index < GRADER_SCENES.size():
 		var inst = GRADER_SCENES[index].instantiate()
 		$ActualGraderContainer/GraderMarginContainer.add_child(inst)
+		_connect_gui_input_signals(inst)
 
 func _on_delete_button_pressed() -> void:
 	queue_free()
-	
+
 func verify_grader() -> bool:
 	return true
+
+func _on_verify_timeout() -> void:
+	verify_grader()
+
+func _schedule_verify() -> void:
+	_verify_timer.start()
+
+func _on_any_gui_input(event: InputEvent) -> void:
+	_schedule_verify()
+
+func _on_child_entered(child: Node) -> void:
+	_connect_gui_input_signals(child)
+
+func _connect_gui_input_signals(node: Node) -> void:
+	if node is Control:
+		if not node.is_connected("gui_input", Callable(self, "_on_any_gui_input")):
+			node.connect("gui_input", Callable(self, "_on_any_gui_input"))
+	if not node.is_connected("child_entered_tree", Callable(self, "_on_child_entered")):
+		node.connect("child_entered_tree", Callable(self, "_on_child_entered"))
+	for child in node.get_children():
+		_connect_gui_input_signals(child)
+


### PR DESCRIPTION
## Summary
- trigger grader verification with debounce when UI changes
- connect GUI input events recursively for all controls

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688d609c87d08320b884fe683d7d2450