### PR TITLE
Print data when verifying graders

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -33,6 +33,10 @@ func _on_delete_button_pressed() -> void:
 
 func verify_grader() -> bool:
 	print("Verifying grader!")
+	var grader := $ActualGraderContainer/GraderMarginContainer.get_child_count() > 0 ? $ActualGraderContainer/GraderMarginContainer.get_child(0) : null
+	if grader and grader.has_method("to_var"):
+		var data := grader.to_var()
+		print(data)
 	return true
 
 func _on_verify_timeout() -> void:


### PR DESCRIPTION
## Summary
- enhance `verify_grader` to show grader info for debugging
- fix indentation so debug output aligns with conditional

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688d6647863c832087776896bb52938c