### PR TITLE
Allow selecting specific grader types in multi-grader

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -1,17 +1,37 @@
 extends VBoxContainer
 
-@onready var GRADER_SCENE: PackedScene = load(get_script().resource_path.get_base_dir().path_join("grader_container.tscn"))
+
+@onready var GRADER_SCENES: Array[PackedScene] = [
+	preload("res://scenes/graders/string_check_grader.tscn"),
+	preload("res://scenes/graders/string_similarity_grader.tscn"),
+	preload("res://scenes/graders/score_model_grader.tscn"),
+	preload("res://scenes/graders/label_model_grader.tscn"),
+	preload("res://scenes/graders/python_grader.tscn"),
+	preload("res://scenes/graders/multi_grader.tscn")
+]
+
+@onready var _grader_type_option_button: OptionButton = $GradersContainer/AddGraderControls/GraderTypeOptionButton
 
 func _ready() -> void:
 	pass
 
 func _on_add_grader_button_pressed() -> void:
-	var wrapper := MarginContainer.new()
-	wrapper.layout_mode = 2
-	wrapper.size_flags_vertical = 3
-	wrapper.add_theme_constant_override("margin_left", 50)
-	var inst := GRADER_SCENE.instantiate()
-	wrapper.add_child(inst)
-	inst.connect("tree_exited", Callable(wrapper, "queue_free"))
-	$GradersContainer.add_child(wrapper)
-	$GradersContainer.move_child($GradersContainer/AddGraderButton, -1)
+	var index := _grader_type_option_button.selected
+	if index >= 0 and index < GRADER_SCENES.size():
+		var margin_wrapper := MarginContainer.new()
+		margin_wrapper.layout_mode = 2
+		margin_wrapper.size_flags_vertical = 3
+		margin_wrapper.add_theme_constant_override("margin_left", 50)
+		var container := VBoxContainer.new()
+		container.layout_mode = 2
+		var inst := GRADER_SCENES[index].instantiate()
+		container.add_child(inst)
+		var delete_button := Button.new()
+		delete_button.text = "Delete Grader"
+		delete_button.connect("pressed", Callable(margin_wrapper, "queue_free"))
+		container.add_child(delete_button)
+		margin_wrapper.add_child(container)
+		inst.connect("tree_exited", Callable(margin_wrapper, "queue_free"))
+		$GradersContainer.add_child(margin_wrapper)
+		$GradersContainer.move_child($GradersContainer/AddGraderControls, -1)
+

--- a/src/scenes/graders/multi_grader.tscn
+++ b/src/scenes/graders/multi_grader.tscn
@@ -14,7 +14,27 @@ script = ExtResource("1_mulgr")
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="AddGraderButton" type="Button" parent="GradersContainer"]
+[node name="AddGraderControls" type="HBoxContainer" parent="GradersContainer"]
+layout_mode = 2
+
+[node name="GraderTypeOptionButton" type="OptionButton" parent="GradersContainer/AddGraderControls"]
+layout_mode = 2
+size_flags_horizontal = 3
+item_count = 6
+popup/item_0/text = "String Check Grader"
+popup/item_0/id = 0
+popup/item_1/text = "String Similarity Grader"
+popup/item_1/id = 1
+popup/item_2/text = "Score Model Grader"
+popup/item_2/id = 2
+popup/item_3/text = "Label Model Grader"
+popup/item_3/id = 3
+popup/item_4/text = "Python Grader"
+popup/item_4/id = 4
+popup/item_5/text = "Multi Grader"
+popup/item_5/id = 5
+
+[node name="AddGraderButton" type="Button" parent="GradersContainer/AddGraderControls"]
 layout_mode = 2
 text = "Add Grader"
 
@@ -32,4 +52,4 @@ text = "Score Formula:"
 layout_mode = 2
 size_flags_horizontal = 3
 
-[connection signal="pressed" from="GradersContainer/AddGraderButton" to="." method="_on_add_grader_button_pressed"]
+[connection signal="pressed" from="GradersContainer/AddGraderControls/AddGraderButton" to="." method="_on_add_grader_button_pressed"]


### PR DESCRIPTION
## Summary
- add option button to choose grader type before adding
- insert selected grader scenes directly with delete control

## Testing
- `godot --headless -s tests/test_application_start.gd` *(fails: Unable to open imported resources)*
- `./check_tabs.sh src/scenes/graders/multi_grader.gd src/scenes/graders/multi_grader.tscn`


------
https://chatgpt.com/codex/tasks/task_e_688e2d81e5fc83208ef88001d62cbb53