### PR TITLE
Add message-based inputs to graders

### DIFF
--- a/src/scenes/graders/label_model_grader.gd
+++ b/src/scenes/graders/label_model_grader.gd
@@ -14,6 +14,11 @@ func to_var():
 	me["type"] = "label_model"
 	me["name"] = $NameContainer.grader_name
 	me["model"] = $ModelContainer.model_name
+	me["input"] = []
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			me["input"].append(msg.to_grader_var())
 	me["labels"] = []
 	me["passing_labels"] = []
 	for labelix in range($LabelsList.item_count):

--- a/src/scenes/graders/score_model_grader.gd
+++ b/src/scenes/graders/score_model_grader.gd
@@ -1,6 +1,13 @@
 extends VBoxContainer
 
-# TODO: Prompt missing
+var MESSAGE_SCENE = preload("res://scenes/message.tscn")
+
+func _ready() -> void:
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			msg._on_message_type_item_selected(msg.get_node("MessageSettingsContainer/MessageType").selected)
+
 func to_var():
 	var me = {}
 	me["type"] = "score_model"
@@ -12,8 +19,13 @@ func to_var():
 		"top_p": float($SamplingParametersContainer/TopPEdit.text),
 		"seed": int($SamplingParametersContainer/SeedEdit.text)
 	}
+	me["input"] = []
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			me["input"].append(msg.to_grader_var())
 	return me
-	
+
 func from_var(grader_data):
 	$NameContainer.grader_name = grader_data.get("name", "")
 	$ModelContainer.model_name = grader_data.get("model", "")
@@ -22,4 +34,15 @@ func from_var(grader_data):
 	$SamplingParametersContainer/TemperatureEdit.text = str(grader_data.get("sampling_params", {}).get("temperature", 1))
 	$SamplingParametersContainer/TopPEdit.text = str(grader_data.get("sampling_params", {}).get("top_p", 1))
 	$SamplingParametersContainer/SeedEdit.text = str(grader_data.get("sampling_params", {}).get("seed", 42))
+
+func _on_add_message_button_pressed() -> void:
+	var container = MarginContainer.new()
+	container.layout_mode = 2
+	container.add_theme_constant_override("margin_left", 90)
+	container.add_theme_constant_override("margin_right", 95)
+	var msg = MESSAGE_SCENE.instantiate()
+	container.add_child(msg)
+	msg._on_message_type_item_selected(msg.get_node("MessageSettingsContainer/MessageType").selected)
+	$MessagesContainer.add_child(container)
+	$MessagesContainer.move_child($MessagesContainer/AddMessageButton, -1)
 	

--- a/src/scenes/graders/score_model_grader.tscn
+++ b/src/scenes/graders/score_model_grader.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cgski2qyhb6o6"]
+[gd_scene load_steps=5 format=3 uid="uid://cgski2qyhb6o6"]
 
 [ext_resource type="Script" uid="uid://dhjbnnkv3sacx" path="res://scenes/graders/score_model_grader.gd" id="1_wkgte"]
 [ext_resource type="PackedScene" uid="uid://dawsni6j2ydhu" path="res://scenes/graders/grader_name_container.tscn" id="1_xre7k"]
+[ext_resource type="PackedScene" uid="uid://clmrayf2uklte" path="res://scenes/message.tscn" id="2_ll3dp"]
 [ext_resource type="PackedScene" uid="uid://cukb0mp1ky25c" path="res://scenes/model_choice_container.tscn" id="3_f2a6w"]
 
 [node name="ScoreModelGrader" type="VBoxContainer"]
@@ -15,13 +16,33 @@ script = ExtResource("1_wkgte")
 [node name="NameContainer" parent="." instance=ExtResource("1_xre7k")]
 layout_mode = 2
 
-[node name="PromptLabel" type="Label" parent="."]
-layout_mode = 2
-text = "Model input/Prompt:"
 
-[node name="PromptEdit" type="TextEdit" parent="."]
-custom_minimum_size = Vector2(0, 250)
+[node name="MessagesLabel" type="Label" parent="."]
 layout_mode = 2
+text = "Messages:"
+
+[node name="MessagesContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="MessagesContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 90
+theme_override_constants/margin_right = 95
+
+[node name="Message" parent="MessagesContainer/MarginContainer" instance=ExtResource("2_ll3dp")]
+layout_mode = 2
+
+[node name="MarginContainer2" type="MarginContainer" parent="MessagesContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 90
+theme_override_constants/margin_right = 95
+
+[node name="Message" parent="MessagesContainer/MarginContainer2" instance=ExtResource("2_ll3dp")]
+layout_mode = 2
+
+[node name="AddMessageButton" type="Button" parent="MessagesContainer"]
+layout_mode = 2
+text = "Add Message"
 
 [node name="ModelContainer" parent="." instance=ExtResource("3_f2a6w")]
 layout_mode = 2
@@ -78,3 +99,5 @@ text = "Seed:"
 
 [node name="SeedEdit" type="LineEdit" parent="SamplingParametersContainer"]
 layout_mode = 2
+
+[connection signal="pressed" from="MessagesContainer/AddMessageButton" to="." method="_on_add_message_button_pressed"]


### PR DESCRIPTION
## Summary
- populate `input` field in label model grader `to_var`
- add message list support for score model grader and include it in `to_var`

## Testing
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e828ecfd4832080518334cc3bd1f5