### PR TITLE
Fix duplicate model entries in model choice option button

### DIFF
--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -98,6 +98,7 @@ func _on_schema_file_loaded(file_name: String, file_type: String, base64_data: S
 
 func models_received(models: Array[String]):
 	# Make the selectable models the models that are given back here
+	$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.clear()
 	for m in models:
 		$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.add_item(m)
 # Called every frame. 'delta' is the elapsed time since the previous frame.


### PR DESCRIPTION
## Summary
- Clear existing models before adding new ones to the model choice OptionButton to avoid duplicate entries.

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_application_start.gd` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_688e85bd266883209327d1d58996ac31