### PR TITLE
Handle grader validation errors

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -46,6 +46,13 @@ func verify_grader() -> bool:
 
 func _on_grader_validation_completed(response: Dictionary) -> void:
 	print(response)
+	var error_label := $ErrorMessageLabel
+	if response.has("error"):
+		error_label.text = response.get("error", {}).get("message", "")
+		error_label.visible = true
+	else:
+		error_label.text = ""
+		error_label.visible = false
 
 func _on_verify_timeout() -> void:
 	verify_grader()

--- a/src/scenes/graders/grader_container.tscn
+++ b/src/scenes/graders/grader_container.tscn
@@ -87,9 +87,10 @@ theme_override_styles/separator = SubResource("StyleBoxLine_b487k")
 
 [node name="ErrorMessageLabel" type="Label" parent="."]
 layout_mode = 2
+visible = false
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
-text = "Image inputs are not supported for grader model: gpt-4-0613. Try again with a vision model. To find out which models are vision-enabled, visit our our models documentation: https://platform.openai.com/docs/models"
+text = ""
 autowrap_mode = 2
 
 [connection signal="item_selected" from="GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton" to="." method="_on_grader_type_option_button_item_selected"]


### PR DESCRIPTION
## Summary
- Show grader validation errors in UI and hide when successful
- Hide error message label by default

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/openai_import_test.gd`
- `godot --headless --path src -s tests/test_load_examples.gd`
- `godot --headless --path src -s tests/test_application_start.gd` *(fails: Unable to open file: res://.godot/imported/wrench.png-340b05fa4e28b2e024a455ac9a965458.ctex)*
- `godot --headless --path src -s tests/test_import_openai.gd` *(fails: Identifier "FileAccessWeb" not declared in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_688e88dfaf388320a9880dfb27f9bc8f