### PR TITLE
Fix duplicated model entries in grader selector

### DIFF
--- a/src/scenes/model_choice_container.gd
+++ b/src/scenes/model_choice_container.gd
@@ -15,9 +15,12 @@ var model_name: String:
 
 func refresh_models():
 	$ModelOptionButton.clear()
+	availablemodelslist.clear()
 	for modelname in settingsdict.get("availableModels", []):
-		$ModelOptionButton.add_item(modelname)
-		
-	
+		if not availablemodelslist.has(modelname):
+			availablemodelslist.append(modelname)
+			$ModelOptionButton.add_item(modelname)
+	settingsdict["availableModels"] = availablemodelslist
+
 func _ready() -> void:
 	refresh_models()


### PR DESCRIPTION
## Summary
- avoid repeated model entries when refreshing grader model selector
- keep available models list unique in settings

## Testing
- `bash check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e8963bb7c83209e1d5f1f22e1613a