### PR TITLE
Show spinner during grader verification

### DIFF
--- a/src/scenes/graders/grader_container.tscn
+++ b/src/scenes/graders/grader_container.tscn
@@ -65,7 +65,7 @@ layout_mode = 2
 
 [node name="GraderVerificationStatus" type="Label" parent="GraderSettingsContainer"]
 layout_mode = 2
-text = "Grader verified!"
+text = "GRADER_NOT_VERIFIED_YET"
 
 [node name="Spinner" parent="GraderSettingsContainer" instance=ExtResource("2_kgw4v")]
 visible = false


### PR DESCRIPTION
## Summary
- show spinner only during grader verification and update status label with translated strings
- default verification label uses translatable string

## Testing
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e8e5629a08320afc558cef0a7583d