### PR TITLE
Add serialization helpers for multi grader

### DIFF
--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -15,6 +15,68 @@ extends VBoxContainer
 func _ready() -> void:
 	pass
 
+func to_var():
+	var me = {}
+	me["type"] = "multi"
+	var name_container = get_node_or_null("NameContainer")
+	me["name"] = name_container.grader_name if name_container else ""
+	me["graders"] = []
+	for child in $GradersContainer.get_children():
+		if child.name == "AddGraderControls":
+			continue
+		var container = child.get_child(0)
+		var grader = container.get_child(0)
+		if grader.has_method("to_var"):
+			me["graders"].append(grader.to_var())
+	me["calculate_output"] = $ScoreFormulaContainer/ScoreFormulaEdit.text
+	return me
+
+func from_var(grader_data):
+	var name_container = get_node_or_null("NameContainer")
+	if name_container:
+		name_container.grader_name = grader_data.get("name", "")
+	$ScoreFormulaContainer/ScoreFormulaEdit.text = grader_data.get("calculate_output", "")
+	for child in $GradersContainer.get_children():
+		if child.name != "AddGraderControls":
+			child.queue_free()
+	for sub in grader_data.get("graders", []):
+		var type = sub.get("type", "")
+		var index = -1
+		match type:
+			"string_check":
+				index = 0
+			"string_similarity":
+				index = 1
+			"score_model":
+				index = 2
+			"label_model":
+				index = 3
+			"python":
+				index = 4
+			"multi":
+				index = 5
+			_:
+				index = -1
+		if index >= 0 and index < GRADER_SCENES.size():
+			var margin_wrapper := MarginContainer.new()
+			margin_wrapper.layout_mode = 2
+			margin_wrapper.size_flags_vertical = 3
+			margin_wrapper.add_theme_constant_override("margin_left", 50)
+			var container := VBoxContainer.new()
+			container.layout_mode = 2
+			var inst := GRADER_SCENES[index].instantiate()
+			container.add_child(inst)
+			var delete_button := Button.new()
+			delete_button.text = "Delete Grader"
+			delete_button.connect("pressed", Callable(margin_wrapper, "queue_free"))
+			container.add_child(delete_button)
+			margin_wrapper.add_child(container)
+			inst.connect("tree_exited", Callable(margin_wrapper, "queue_free"))
+			$GradersContainer.add_child(margin_wrapper)
+			$GradersContainer.move_child($GradersContainer/AddGraderControls, -1)
+			if inst.has_method("from_var"):
+				inst.from_var(sub)
+
 func _on_add_grader_button_pressed() -> void:
 	var index := _grader_type_option_button.selected
 	if index >= 0 and index < GRADER_SCENES.size():


### PR DESCRIPTION
## Summary
- allow MultiGrader scenes to serialize to and from dictionaries

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src --script tests/test_application_start.gd` *(fails: Unable to open file: res://.godot/imported/wrench.png-340b05fa4e28b2e024a455ac9a965458.ctex)*


------
https://chatgpt.com/codex/tasks/task_e_688e8e63307483209da194cb9a80c819