### PR TITLE
Keep selected grader active unless validation fails

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -44,7 +44,6 @@ func _on_delete_button_pressed() -> void:
 func verify_grader() -> bool:
 	print("Verifying grader!")
 	_use_button.disabled = true
-	_use_button.button_pressed = false
 	var grader = $ActualGraderContainer/GraderMarginContainer.get_child(0) if $ActualGraderContainer/GraderMarginContainer.get_child_count() > 0 else null
 	if grader and grader.has_method("to_var"):
 		var data = grader.to_var()
@@ -56,7 +55,12 @@ func verify_grader() -> bool:
 		else:
 			_status_label.text = tr("GRADER_VERIFICATION_ERROR")
 			_spinner.visible = false
+			_use_button.button_pressed = false
 		return true
+	_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+	_spinner.visible = false
+	_use_button.button_pressed = false
+	return false
 
 func _on_grader_validation_completed(response: Dictionary) -> void:
 	print(response)


### PR DESCRIPTION
## Summary
- Preserve `Use this grader` checkbox when re-validating a grader
- Only clear the checkbox if validation fails

## Testing
- `./check_tabs.sh`
- `godot --headless -s tests/test_import_openai.gd` *(fails: Unable to open imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_688e9df5222c8320ba3fcdd15d944961