### PR TITLE
Add form readiness checks to graders

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -46,17 +46,24 @@ func verify_grader() -> bool:
 	_use_button.disabled = true
 	_use_button.button_pressed = false
 	var grader = $ActualGraderContainer/GraderMarginContainer.get_child(0) if $ActualGraderContainer/GraderMarginContainer.get_child_count() > 0 else null
-	if grader and grader.has_method("to_var"):
-		var data = grader.to_var()
-		print(data)
-		if openai:
-			_spinner.visible = true
-			_status_label.text = tr("GRADER_VERIFYING")
-			openai.validate_grader(data)
-		else:
-			_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+	if grader:
+		if grader.has_method("is_form_ready") and not grader.is_form_ready():
+			_status_label.text = tr("GRADER_NOT_VERIFIED_YET")
 			_spinner.visible = false
-		return true
+			return false
+		if grader.has_method("to_var"):
+			var data = grader.to_var()
+			print(data)
+			if openai:
+				_spinner.visible = true
+				_status_label.text = tr("GRADER_VERIFYING")
+				openai.validate_grader(data)
+			else:
+				_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+				_spinner.visible = false
+			return true
+	_status_label.text = tr("GRADER_NOT_VERIFIED_YET")
+	return false
 
 func _on_grader_validation_completed(response: Dictionary) -> void:
 	print(response)

--- a/src/scenes/graders/label_model_grader.gd
+++ b/src/scenes/graders/label_model_grader.gd
@@ -37,6 +37,17 @@ func from_var(grader_data):
 			$LabelsList.add_item(label, passing_icon)
 		else:
 			$LabelsList.add_item(label)
+
+func is_form_ready() -> bool:
+	if $NameContainer.grader_name == "" or $ModelContainer.model_name == "":
+		return false
+	if $LabelsList.item_count == 0:
+		return false
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			return true
+	return false
 			
 
 func _on_labels_list_item_activated(index: int) -> void:

--- a/src/scenes/graders/multi_grader.gd
+++ b/src/scenes/graders/multi_grader.gd
@@ -74,8 +74,25 @@ func from_var(grader_data):
 			inst.connect("tree_exited", Callable(margin_wrapper, "queue_free"))
 			$GradersContainer.add_child(margin_wrapper)
 			$GradersContainer.move_child($GradersContainer/AddGraderControls, -1)
-			if inst.has_method("from_var"):
+		if inst.has_method("from_var"):
 				inst.from_var(sub)
+
+func is_form_ready() -> bool:
+	var name_container = get_node_or_null("NameContainer")
+	if name_container and name_container.grader_name == "":
+		return false
+	if $ScoreFormulaContainer/ScoreFormulaEdit.text == "":
+		return false
+	var has_sub := false
+	for child in $GradersContainer.get_children():
+		if child.name == "AddGraderControls":
+			continue
+		var container = child.get_child(0)
+		var grader = container.get_child(0)
+		if grader.has_method("is_form_ready") and not grader.is_form_ready():
+			return false
+		has_sub = true
+	return has_sub
 
 func _on_add_grader_button_pressed() -> void:
 	var index := _grader_type_option_button.selected

--- a/src/scenes/graders/python_grader.gd
+++ b/src/scenes/graders/python_grader.gd
@@ -12,3 +12,6 @@ func to_var():
 func from_var(grader_data):
 	$NameContainer.grader_name = grader_data.get("name", "")
 	$MarginContainer/PythonEdit.text = grader_data.get("source", "")
+
+func is_form_ready() -> bool:
+	return $NameContainer.grader_name != "" and $MarginContainer/PythonEdit.text != ""

--- a/src/scenes/graders/score_model_grader.gd
+++ b/src/scenes/graders/score_model_grader.gd
@@ -35,6 +35,23 @@ func from_var(grader_data):
 	$SamplingParametersContainer/TopPEdit.text = str(grader_data.get("sampling_params", {}).get("top_p", 1))
 	$SamplingParametersContainer/SeedEdit.text = str(grader_data.get("sampling_params", {}).get("seed", 42))
 
+func is_form_ready() -> bool:
+	if $NameContainer.grader_name == "" or $ModelContainer.model_name == "":
+		return false
+	if $RangeContainer/RangeFromEdit.text == "" or $RangeContainer/RangeToEdit.text == "":
+		return false
+	if (
+		$SamplingParametersContainer/TemperatureEdit.text == "" or
+		$SamplingParametersContainer/TopPEdit.text == "" or
+		$SamplingParametersContainer/SeedEdit.text == ""
+	):
+		return false
+	for child in $MessagesContainer.get_children():
+		var msg = child.get_node_or_null("Message")
+		if msg:
+			return true
+	return false
+
 func _on_add_message_button_pressed() -> void:
 	var container = MarginContainer.new()
 	container.layout_mode = 2

--- a/src/scenes/graders/string_check_grader.gd
+++ b/src/scenes/graders/string_check_grader.gd
@@ -8,10 +8,18 @@ func to_var():
 	me["reference"] = $GridContainer/ReferenceEdit.text
 	me["operation"] = $GridContainer/OperationOptionButton.get_item_text($GridContainer/OperationOptionButton.selected)
 	return me
-	
+
 func from_var(grader_data):
 	$NameContainer.grader_name = grader_data.get("name", "")
 	$GridContainer/InputEdit.text = grader_data.get("input", "")
 	$GridContainer/ReferenceEdit.text = grader_data.get("reference")
 	$GridContainer/OperationOptionButton.select(0)
 	$GridContainer/OperationOptionButton.select($GridContainer/OperationOptionButton.get_item_index(grader_data.get("operation", "eq")))
+
+func is_form_ready() -> bool:
+	return (
+		$NameContainer.grader_name != "" and
+		$GridContainer/InputEdit.text != "" and
+		$GridContainer/ReferenceEdit.text != "" and
+		$GridContainer/OperationOptionButton.selected >= 0
+	)

--- a/src/scenes/graders/string_similarity_grader.gd
+++ b/src/scenes/graders/string_similarity_grader.gd
@@ -17,3 +17,11 @@ func to_var():
 	me["input"] = $InputContainer/InputEdit.text
 	me["reference"] = $ReferenceContainer/ReferenceEdit.text
 	return me
+
+func is_form_ready() -> bool:
+	return (
+		$NameContainer.grader_name != "" and
+		$InputContainer/InputEdit.text != "" and
+		$ReferenceContainer/ReferenceEdit.text != "" and
+		$EvaluationMetricContainer/EvaluationMetricOptionButton.selected >= 0
+	)


### PR DESCRIPTION
## Summary
- ensure grader verification only runs after form completion
- add `is_form_ready()` implementations for all grader types

## Testing
- `godot --headless --path src -s tests/test_application_start.gd 2>&1 | tail -n 20`
- `godot --headless --path src -s tests/openai_import_test.gd 2>&1 | tail -n 20`
- `godot --headless --path src -s tests/test_import_openai.gd 2>&1 | tail -n 20`
- `godot --headless --path src -s tests/test_load_examples.gd 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688ea11aeca08320b425a57e03fe7103