### PR TITLE
Animate grader delete button hover

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -43,6 +43,12 @@ func _on_grader_type_option_button_item_selected(index: int) -> void:
 func _on_delete_button_pressed() -> void:
 	queue_free()
 
+func _on_delete_button_mouse_entered() -> void:
+	$GraderSettingsContainer/DeleteGraderButton.icon = load("res://icons/trashcanOpen_small.png")
+
+func _on_delete_button_mouse_exited() -> void:
+	$GraderSettingsContainer/DeleteGraderButton.icon = load("res://icons/trashcan_small.png")
+
 func _exit_tree() -> void:
 	if _grader:
 		_grader.queue_free()

--- a/src/scenes/graders/grader_container.tscn
+++ b/src/scenes/graders/grader_container.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://bxjaykkfeey4u"]
+[gd_scene load_steps=5 format=3 uid="uid://bxjaykkfeey4u"]
 
 [ext_resource type="Script" uid="uid://cn0tv0hrxm7bj" path="res://scenes/graders/grader_container.gd" id="1_grdc"]
 [ext_resource type="PackedScene" uid="uid://bcc2q2aitqhiy" path="res://scenes/spinner.tscn" id="2_kgw4v"]
+[ext_resource type="Texture2D" uid="uid://c1elx3oj6r7fu" path="res://icons/trashcan_small.png" id="3_trshc"]
 
 [sub_resource type="StyleBoxLine" id="StyleBoxLine_b487k"]
 color = Color(0.266575, 0.266575, 0.266575, 1)
@@ -80,6 +81,7 @@ text = "GRADER_USE_THIS_GRADER"
 [node name="DeleteGraderButton" type="Button" parent="GraderSettingsContainer"]
 layout_mode = 2
 text = "GRADER_DELETE_GRADER"
+icon = ExtResource("3_trshc")
 
 [node name="ErrorMessageLabel" type="Label" parent="."]
 visible = false
@@ -94,4 +96,6 @@ layout_mode = 2
 theme_override_styles/separator = SubResource("StyleBoxLine_b487k")
 
 [connection signal="item_selected" from="GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton" to="." method="_on_grader_type_option_button_item_selected"]
+[connection signal="mouse_entered" from="GraderSettingsContainer/DeleteGraderButton" to="." method="_on_delete_button_mouse_entered"]
+[connection signal="mouse_exited" from="GraderSettingsContainer/DeleteGraderButton" to="." method="_on_delete_button_mouse_exited"]
 [connection signal="pressed" from="GraderSettingsContainer/DeleteGraderButton" to="." method="_on_delete_button_pressed"]


### PR DESCRIPTION
## Summary
- Add trashcan icon to grader delete button with hover animation
- Swap icon to open/closed trashcan on mouse enter/exit

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s res://tests/test_application_start.gd` *(fails: res://icons/trashcan_small.png not imported)*

------
https://chatgpt.com/codex/tasks/task_e_688eac2484b48320acc841235145091c