### PR TITLE
feat: persist graders in project files

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 var FINETUNEDATA = {}
 var FUNCTIONS = []
 var CONVERSATIONS = {}
+var GRADERS = []
 var SETTINGS = {
 	"apikey": "",
 	"useGlobalSystemMessage": false,
@@ -122,6 +123,7 @@ func _process(delta: float) -> void:
 		save_current_conversation()
 		update_functions_internal()
 		update_settings_internal()
+		update_graders_internal()
 		if RUNTIME["filepath"] == "":
 			$VBoxContainer/SaveBtn/SaveFileDialog.visible = true
 		else:
@@ -147,6 +149,10 @@ func _process(delta: float) -> void:
 
 
 func _on_save_btn_pressed() -> void:
+	save_current_conversation()
+	update_functions_internal()
+	update_settings_internal()
+	update_graders_internal()
 	match OS.get_name():
 		"Windows", "Linux", "FreeBSD", "NetBSD", "OpenBSD", "BSD", "Android","macOS":
 			$VBoxContainer/SaveBtn/SaveFileDialog.visible = true
@@ -163,8 +169,10 @@ func update_functions_internal():
 func update_settings_internal():
 	SETTINGS = $Conversation/Settings/ConversationSettings.to_var()
 	print("Settings: ")
-	
+
 	print(SETTINGS)
+func update_graders_internal():
+	GRADERS = $Conversation/Graders/GradersList.to_var()
 func get_available_function_names():
 	var tmpNames = []
 	for f in FUNCTIONS:
@@ -413,6 +421,7 @@ func _on_conversation_tab_changed(tab: int) -> void:
 	save_current_conversation()
 	update_functions_internal()
 	update_settings_internal()
+	update_graders_internal()
 
 
 func create_new_conversation(msgs=[]):
@@ -458,6 +467,7 @@ func save_to_binary(filename):
 	FINETUNEDATA["functions"] = FUNCTIONS
 	FINETUNEDATA["conversations"] = CONVERSATIONS
 	FINETUNEDATA["settings"] = SETTINGS
+	FINETUNEDATA["graders"] = GRADERS
 	var file = FileAccess.open(filename, FileAccess.WRITE)
 	if file:
 		file.store_var(FINETUNEDATA)
@@ -474,12 +484,14 @@ func load_from_binary(filename):
 		FUNCTIONS = FINETUNEDATA["functions"]
 		CONVERSATIONS = FINETUNEDATA["conversations"]
 		SETTINGS = FINETUNEDATA["settings"]
+		GRADERS = FINETUNEDATA.get("graders", [])
 		for i in CONVERSATIONS.keys():
 			CURRENT_EDITED_CONVO_IX = str(i)
 			$Conversation/Functions/FunctionsList.delete_all_functions_from_UI()
 			$Conversation/Messages/MessagesList.delete_all_messages_from_UI()
 			$Conversation/Functions/FunctionsList.from_var(FUNCTIONS)
 			$Conversation/Settings/ConversationSettings.from_var(SETTINGS)
+			$Conversation/Graders/GradersList.from_var(GRADERS)
 			$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 			refresh_conversations_list()
 			$VBoxContainer/ConversationsList.select(selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX))
@@ -497,10 +509,12 @@ func load_from_json_data(jsondata: String):
 	FUNCTIONS = FINETUNEDATA["functions"]
 	CONVERSATIONS = FINETUNEDATA["conversations"]
 	SETTINGS = FINETUNEDATA["settings"]
+	GRADERS = FINETUNEDATA.get("graders", [])
 	for i in CONVERSATIONS.keys():
 		CURRENT_EDITED_CONVO_IX = str(i)
 	$Conversation/Settings/ConversationSettings.from_var(SETTINGS)
 	$Conversation/Functions/FunctionsList.from_var(FUNCTIONS)
+	$Conversation/Graders/GradersList.from_var(GRADERS)
 	$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 	refresh_conversations_list()
 	$VBoxContainer/ConversationsList.select(selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX))
@@ -511,6 +525,7 @@ func make_save_json_data():
 	FINETUNEDATA["functions"] = FUNCTIONS
 	FINETUNEDATA["conversations"] = CONVERSATIONS
 	FINETUNEDATA["settings"] = SETTINGS
+	FINETUNEDATA["graders"] = GRADERS
 	var jsonstr = JSON.stringify(FINETUNEDATA, "\t", false)
 	return jsonstr
 
@@ -543,6 +558,10 @@ func load_from_appropriate_from_path(path):
 
 
 func _on_save_file_dialog_file_selected(path: String) -> void:
+	save_current_conversation()
+	update_functions_internal()
+	update_settings_internal()
+	update_graders_internal()
 	if path.ends_with(".json"):
 		save_to_json(path)
 	elif path.ends_with(".ftproj"):

--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -136,3 +136,41 @@ func _connect_gui_input_signals(node: Node) -> void:
 		node.connect("child_entered_tree", Callable(self, "_on_child_entered"))
 	for child in node.get_children():
 		_connect_gui_input_signals(child)
+
+func to_var():
+	var result = {"use": _use_button.button_pressed, "grader": {}}
+	var grader_gui = null
+	if $ActualGraderContainer/GraderMarginContainer.get_child_count() > 0:
+		grader_gui = $ActualGraderContainer/GraderMarginContainer.get_child(0)
+	if grader_gui and grader_gui.has_method("to_var"):
+		result["grader"] = grader_gui.to_var()
+	return result
+
+func from_var(data):
+	_use_button.button_pressed = data.get("use", false)
+	var grader_data = data.get("grader", {})
+	var type = grader_data.get("type", "")
+	var index = 0
+	match type:
+		"string_check":
+			index = 0
+		"string_similarity":
+			index = 1
+		"score_model":
+			index = 2
+		"label_model":
+			index = 3
+		"python":
+			index = 4
+		"multi":
+			index = 5
+		_:
+			index = 0
+	$GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.select(index)
+	_on_grader_type_option_button_item_selected(index)
+	var grader_gui = null
+	if $ActualGraderContainer/GraderMarginContainer.get_child_count() > 0:
+		grader_gui = $ActualGraderContainer/GraderMarginContainer.get_child(0)
+	if grader_gui and grader_gui.has_method("from_var"):
+		grader_gui.from_var(grader_data)
+

--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -6,3 +6,24 @@ func _on_add_grader_button_pressed() -> void:
 	var inst = GRADER_SCENE.instantiate()
 	$GradersListContainer.add_child(inst)
 	$GradersListContainer.move_child($GradersListContainer/AddGraderButton, -1)
+
+func to_var():
+	var all = []
+	for child in $GradersListContainer.get_children():
+		if child.name == "AddGraderButton":
+			continue
+		if child.has_method("to_var"):
+			all.append(child.to_var())
+	return all
+
+func from_var(graders_data):
+	for child in $GradersListContainer.get_children():
+		if child.name != "AddGraderButton":
+			child.queue_free()
+	if graders_data is Array:
+		for g in graders_data:
+			var inst = GRADER_SCENE.instantiate()
+			$GradersListContainer.add_child(inst)
+			$GradersListContainer.move_child($GradersListContainer/AddGraderButton, -1)
+			if inst.has_method("from_var"):
+				inst.from_var(g)


### PR DESCRIPTION
## Summary
- save and restore grader configurations via new GRADERS project key
- rebuild graders with their "use" state when loading projects

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688eb348cff483209e584f283e272356