### PR TITLE
Fix OptionButton selection when loading graders

### DIFF
--- a/src/scenes/graders/string_check_grader.gd
+++ b/src/scenes/graders/string_check_grader.gd
@@ -14,7 +14,11 @@ func from_var(grader_data):
 	$GridContainer/InputEdit.text = grader_data.get("input", "")
 	$GridContainer/ReferenceEdit.text = grader_data.get("reference")
 	$GridContainer/OperationOptionButton.select(0)
-	$GridContainer/OperationOptionButton.select($GridContainer/OperationOptionButton.get_item_index(grader_data.get("operation", "eq")))
+	var operation = grader_data.get("operation", "eq")
+	for i in range($GridContainer/OperationOptionButton.item_count):
+		if $GridContainer/OperationOptionButton.get_item_text(i) == operation:
+			$GridContainer/OperationOptionButton.select(i)
+			break
 
 func is_form_ready() -> bool:
 	return (

--- a/src/scenes/graders/string_similarity_grader.gd
+++ b/src/scenes/graders/string_similarity_grader.gd
@@ -5,9 +5,11 @@ func from_var(grader_data):
 	$InputContainer/InputEdit.text = grader_data.get("input", "")
 	$ReferenceContainer/ReferenceEdit.text = grader_data.get("reference", "")
 	$EvaluationMetricContainer/EvaluationMetricOptionButton.select(-1)
-	for optix in $EvaluationMetricContainer/EvaluationMetricOptionButton.item_count:
-		if $EvaluationMetricContainer/EvaluationMetricOptionButton.get_item_text() == grader_data.get("evaluation_metric", "THISWILLNEVERBETRUE"):
+	var metric = grader_data.get("evaluation_metric", "")
+	for optix in range($EvaluationMetricContainer/EvaluationMetricOptionButton.item_count):
+		if $EvaluationMetricContainer/EvaluationMetricOptionButton.get_item_text(optix) == metric:
 			$EvaluationMetricContainer/EvaluationMetricOptionButton.select(optix)
+			break
 
 func to_var():
 	var me = {}


### PR DESCRIPTION
## Summary
- ensure String Check grader selects operation by matching text
- iterate through evaluation metrics to restore selection in String Similarity grader

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --check-only` *(fails: Unable to open file: res://.godot/imported/wrench.png...)*

------
https://chatgpt.com/codex/tasks/task_e_688eb89ead608320814b09dd3751848e