### PR TITLE
Fix grader/chat assignment and add grader signal test

### DIFF
--- a/src/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/src/addons/openai_api/Scripts/OpenAiApi.gd
@@ -78,12 +78,15 @@ func _ready():
 	call_deferred("add_child", grader_inst.instantiate())
 	
 func _process(delta):
-	if dalle and chatgpt and models and grader:
+	if chatgpt and dalle and models and grader:
 		set_process(false)
-	if get_children() == []:
 		return
-
-	chatgpt = get_children()[0]
-	dalle = get_children()[1]
-	models = get_children()[2]
-	grader = get_children()[3]
+	for child in get_children():
+		if !chatgpt and child is ChatGpt:
+			chatgpt = child
+		elif !dalle and child is Dalle:
+			dalle = child
+		elif !models and child is Models:
+			models = child
+		elif !grader and child is Grader:
+			grader = child

--- a/src/tests/test_grader.gd
+++ b/src/tests/test_grader.gd
@@ -1,0 +1,41 @@
+extends SceneTree
+
+var run_called := false
+var validate_called := false
+var parent_run_called := false
+var parent_validate_called := false
+
+func _init():
+	var parent = Node.new()
+	parent.add_user_signal('grader_run_completed')
+	parent.add_user_signal('grader_validation_completed')
+	get_root().add_child(parent)
+	var Grader = load('res://addons/openai_api/Scripts/Grader.gd')
+	var g = Grader.new()
+	parent.add_child(g)
+	await create_timer(0).timeout
+	g.connect('run_completed', _on_run)
+	g.connect('validation_completed', _on_validate)
+	parent.connect('grader_run_completed', _on_parent_run)
+	parent.connect('grader_validation_completed', _on_parent_validate)
+	var body = JSON.stringify({'ok': true}).to_utf8_buffer()
+	g._run_request_completed(HTTPRequest.RESULT_SUCCESS, 200, [], body)
+	g._validate_request_completed(HTTPRequest.RESULT_SUCCESS, 200, [], body)
+	assert(run_called)
+	assert(validate_called)
+	assert(parent_run_called)
+	assert(parent_validate_called)
+	print('Grader signals propagated')
+	quit(0)
+
+func _on_run(response):
+	run_called = true
+
+func _on_validate(response):
+	validate_called = true
+
+func _on_parent_run(response):
+	parent_run_called = true
+
+func _on_parent_validate(response):
+	parent_validate_called = true


### PR DESCRIPTION
## Summary
- Avoid assigning nodes by index in `OpenAiApi` to prevent cross-type assignments
- Add `test_grader.gd` to ensure grader emits run and validation signals

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_grader.gd`
- `godot --headless --path src -s tests/test_application_start.gd` *(fails: resources missing)*
- `godot --headless --path src -s tests/test_load_examples.gd`
- `godot --headless --path src -s tests/test_import_openai.gd` *(multiple resource errors; tests run: 31, Failures: 0)*
- `godot --headless --path src -s tests/openai_import_test.gd`

------
https://chatgpt.com/codex/tasks/task_e_688ebc1ab7f883209b25f1eb90ebdf27