### PR TITLE
Avoid re-verifying grader on middle mouse events

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -113,6 +113,9 @@ func _schedule_verify() -> void:
 func _on_any_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		return
+	if event is InputEventMouseButton:
+		if event.button_index in [MOUSE_BUTTON_MIDDLE, MOUSE_BUTTON_WHEEL_UP, MOUSE_BUTTON_WHEEL_DOWN, MOUSE_BUTTON_WHEEL_LEFT, MOUSE_BUTTON_WHEEL_RIGHT]:
+			return
 	_schedule_verify()
 
 func _on_use_this_grader_button_toggled(pressed: bool) -> void:


### PR DESCRIPTION
## Summary
- Ignore middle mouse and scroll wheel inputs when scheduling grader verification

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_grader.gd`


------
https://chatgpt.com/codex/tasks/task_e_688ec418ffdc8320b040982289c3e642