### PR TITLE
Increase verification timer to 2s

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 	$GraderHeaderMarginContainer/LabelAndChoiceBoxContainer/GraderTypeOptionButton.connect("item_selected", _on_grader_type_option_button_item_selected)
 	_verify_timer = Timer.new()
 	_verify_timer.one_shot = true
-	_verify_timer.wait_time = 0.75
+	_verify_timer.wait_time = 2.0
 	add_child(_verify_timer)
 	_verify_timer.connect("timeout", Callable(self, "_on_verify_timeout"))
 	if openai:


### PR DESCRIPTION
## Summary
- extend grader verification timer from 0.75s to 2s to allow more time before verification runs

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --script tests/test_import_openai.gd` *(resource warnings, Tests run: 31, Failures: 0)*

------
https://chatgpt.com/codex/tasks/task_e_688f7d1247188320a727a09271227f39