### PR TITLE
Ensure GridContainer stays after AddGrader button

### DIFF
--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -5,25 +5,32 @@ extends ScrollContainer
 func _on_add_grader_button_pressed() -> void:
 	var inst = GRADER_SCENE.instantiate()
 	$GradersListContainer.add_child(inst)
-	$GradersListContainer.move_child($GradersListContainer/AddGraderButton, -1)
+	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
+	var btn_index = $GradersListContainer.get_children().find($GradersListContainer/AddGraderButton)
+	$GradersListContainer.move_child(inst, btn_index)
+
 
 func to_var():
 	var all = []
 	for child in $GradersListContainer.get_children():
-		if child.name == "AddGraderButton":
+		if child.name == "AddGraderButton" or child.name == "SampleItemsContainer":
 			continue
 		if child.has_method("to_var"):
 			all.append(child.to_var())
 	return all
 
+
 func from_var(graders_data):
 	for child in $GradersListContainer.get_children():
-		if child.name != "AddGraderButton":
+		if child.name != "AddGraderButton" and child.name != "SampleItemsContainer":
 			child.queue_free()
+	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
 	if graders_data is Array:
 		for g in graders_data:
 			var inst = GRADER_SCENE.instantiate()
 			$GradersListContainer.add_child(inst)
-			$GradersListContainer.move_child($GradersListContainer/AddGraderButton, -1)
+			$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
+			var btn_index = $GradersListContainer.get_children().find($GradersListContainer/AddGraderButton)
+			$GradersListContainer.move_child(inst, btn_index)
 			if inst.has_method("from_var"):
 				inst.from_var(g)


### PR DESCRIPTION
## Summary
- keep sample item GridContainer below the AddGrader button
- ignore SampleItemsContainer when serializing or rebuilding graders

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_grader.gd`
- `godot --headless --path src -s tests/test_application_start.gd` *(fails: failed loading resources)*
- `godot --headless --path src -s tests/test_load_examples.gd`


------
https://chatgpt.com/codex/tasks/task_e_688f89f9849c832082602f57e8bd28eb