### PR TITLE
Use sample item and output when running graders

### DIFF
--- a/src/addons/openai_api/Scripts/Grader.gd
+++ b/src/addons/openai_api/Scripts/Grader.gd
@@ -18,7 +18,7 @@ func _ready():
 	add_child(http_request_validate)
 	http_request_validate.request_completed.connect(self._validate_request_completed)
 
-func run_grader(grader: Dictionary, model_sample: String, item: Dictionary = {}, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
+func run_grader(grader: Dictionary, model_sample, item = null, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
 	var openai_api_key = parent.get_api()
 	if !openai_api_key:
 		return
@@ -30,8 +30,15 @@ func run_grader(grader: Dictionary, model_sample: String, item: Dictionary = {},
 		"grader": grader,
 		"model_sample": model_sample
 	}
-	if !item.is_empty():
-		body["item"] = item
+	if item != null:
+		if item is String:
+			if item != "":
+				body["item"] = item
+		elif item is Dictionary:
+			if !item.is_empty():
+				body["item"] = item
+		else:
+			body["item"] = item
 	var json = JSON.new()
 	var body_json = json.stringify(body)
 	var error = http_request_run.request(url, headers, HTTPClient.METHOD_POST, body_json)

--- a/src/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/src/addons/openai_api/Scripts/OpenAiApi.gd
@@ -35,13 +35,10 @@ func prompt_dalle(prompt:String, resolution:String = "1024x1024", model: String 
 		
 	dalle.prompt_dalle(prompt,resolution,model,url)
 
-func run_grader(grader_obj: Dictionary, model_sample: String, item: Dictionary = {}, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
-
+func run_grader(grader_obj: Dictionary, model_sample, item = null, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
 	while !grader:
 		await get_tree().create_timer(0.2).timeout
-
 	grader.run_grader(grader_obj, model_sample, item, url)
-
 func validate_grader(grader_obj: Dictionary, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/validate"):
 
 	while !grader:

--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -91,6 +91,16 @@ func verify_grader() -> bool:
 	_use_button.button_pressed = false
 	return false
 
+func _parse_json_or_string(text: String):
+	var stripped = text.strip_edges()
+	if stripped == "":
+		return ""
+	var json = JSON.new()
+	var err = json.parse(stripped)
+	if err == OK:
+		return json.get_data()
+	return stripped
+
 func _on_grader_validation_completed(response: Dictionary) -> void:
 	print(response)
 	var error_label := $ErrorMessageLabel
@@ -106,7 +116,17 @@ func _on_grader_validation_completed(response: Dictionary) -> void:
 		error_label.visible = false
 		if _last_grader_data and _grader:
 			_spinner.visible = true
-			_grader.run_grader(_last_grader_data, "", {})
+			var list_container = get_parent()
+			var model_sample = ""
+			var item = null
+			if list_container:
+				var model_node = list_container.get_node_or_null("SampleItemsContainer/SampleModelOutputEdit")
+				if model_node:
+					model_sample = _parse_json_or_string(model_node.text)
+				var item_node = list_container.get_node_or_null("SampleItemsContainer/SampleItemTextEdit")
+				if item_node:
+					item = _parse_json_or_string(item_node.text)
+			_grader.run_grader(_last_grader_data, model_sample, item)
 		else:
 			_status_label.text = tr("GRADER_VERIFIED")
 			_use_button.disabled = false


### PR DESCRIPTION
## Summary
- Allow `Grader` API to accept non-string model samples and items by detecting JSON content before sending requests.
- Add JSON parsing of sample item and model output from the list container when running a grader.
- Expose new run_grader API in `OpenAiApi` to forward these variant inputs.

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_grader.gd`
- `python scripts/test-image-upload.py http://127.0.0.1:8000/image-upload.php --key test --ext png` *(fails: invalid key)*

------
https://chatgpt.com/codex/tasks/task_e_688f9f95a4848320bff334bfb108218d