### PR TITLE
Generate copyable data from grader samples

### DIFF
--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -1,6 +1,13 @@
 extends ScrollContainer
 
 @onready var GRADER_SCENE = preload("res://scenes/graders/grader_container.tscn")
+@onready var COPYABLE_SCENE = preload("res://scenes/graders/copy_able_data_container.tscn")
+
+func _ready():
+	var container = $GradersListContainer/SampleItemsContainer
+	container/SampleItemTextEdit.text_changed.connect(_update_copyable_data)
+	container/SampleModelOutputEdit.text_changed.connect(_update_copyable_data)
+	_update_copyable_data()
 
 func _on_add_grader_button_pressed() -> void:
 	var inst = GRADER_SCENE.instantiate()
@@ -8,7 +15,6 @@ func _on_add_grader_button_pressed() -> void:
 	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
 	var btn_index = $GradersListContainer.get_children().find($GradersListContainer/AddGraderButton)
 	$GradersListContainer.move_child(inst, btn_index)
-
 
 func to_var():
 	var all = []
@@ -18,7 +24,6 @@ func to_var():
 		if child.has_method("to_var"):
 			all.append(child.to_var())
 	return all
-
 
 func from_var(graders_data):
 	for child in $GradersListContainer.get_children():
@@ -34,3 +39,46 @@ func from_var(graders_data):
 			$GradersListContainer.move_child(inst, btn_index)
 			if inst.has_method("from_var"):
 				inst.from_var(g)
+
+func _update_copyable_data():
+	var container = $GradersListContainer/SampleItemsContainer
+	while container.get_child_count() > 4:
+		container.get_child(4).queue_free()
+	var item_paths = []
+	var item_text = container/SampleItemTextEdit.text
+	var json = JSON.new()
+	if json.parse(item_text) == OK:
+		_collect_paths("item", json.data, item_paths)
+	var model_paths = ["{{ sample.output_text }}"]
+	json = JSON.new()
+	var model_text = container/SampleModelOutputEdit.text
+	if json.parse(model_text) == OK:
+		_collect_paths("sample.output_json", json.data, model_paths)
+	var max_len = max(item_paths.size(), model_paths.size())
+	for i in range(max_len):
+		var item_inst = COPYABLE_SCENE.instantiate()
+		if i < item_paths.size():
+			item_inst.dataStr = item_paths[i]
+			item_inst.copyable = true
+		else:
+			item_inst.dataStr = ""
+			item_inst.copyable = false
+		container.add_child(item_inst)
+		var model_inst = COPYABLE_SCENE.instantiate()
+		if i < model_paths.size():
+			model_inst.dataStr = model_paths[i]
+			model_inst.copyable = true
+		else:
+			model_inst.dataStr = ""
+			model_inst.copyable = false
+		container.add_child(model_inst)
+
+func _collect_paths(prefix, value, paths):
+	if value is Dictionary:
+		for k in value.keys():
+			_collect_paths(prefix + "." + str(k), value[k], paths)
+	elif value is Array:
+		for i in range(value.size()):
+			_collect_paths(prefix + "[" + str(i) + "]", value[i], paths)
+	else:
+		paths.append("{{ %s }}" % prefix)

--- a/src/scenes/graders/graders_list.tscn
+++ b/src/scenes/graders/graders_list.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://cg03wm3eel1gm"]
 
 [ext_resource type="Script" uid="uid://dysm5yrejge2q" path="res://scenes/graders/graders.gd" id="1_q6jjh"]
-[ext_resource type="PackedScene" uid="uid://bigrkry77s622" path="res://scenes/graders/copy_able_data_container.tscn" id="2_vpvhw"]
 
 [node name="GradersList" type="ScrollContainer"]
 anchors_preset = 15
@@ -49,23 +48,5 @@ text = "{
 custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
 text = "fuzzy wuzzy was a bear"
-
-[node name="CopyAbleDataContainer" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
-
-[node name="CopyAbleDataContainer2" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
-
-[node name="CopyAbleDataContainer3" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
-
-[node name="CopyAbleDataContainer4" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
-
-[node name="CopyAbleDataContainer5" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
-
-[node name="CopyAbleDataContainer6" parent="GradersListContainer/SampleItemsContainer" instance=ExtResource("2_vpvhw")]
-layout_mode = 2
 
 [connection signal="pressed" from="GradersListContainer/AddGraderButton" to="." method="_on_add_grader_button_pressed"]

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -1,0 +1,30 @@
+extends SceneTree
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var scene = load("res://scenes/graders/graders_list.tscn").instantiate()
+	get_root().add_child(scene)
+	await create_timer(0).timeout
+	var container = scene.get_node("GradersListContainer/SampleItemsContainer")
+	var item_edit = container.get_node("SampleItemTextEdit")
+	var model_edit = container.get_node("SampleModelOutputEdit")
+	item_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
+	model_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
+	scene._update_copyable_data()
+	var datas = []
+	for i in range(4, container.get_child_count()):
+		datas.append(container.get_child(i).dataStr)
+	assert(datas == [
+		"{{ item.reference_answer }}",
+		"{{ sample.output_text }}",
+		"{{ item.moreData.a }}",
+		"{{ sample.output_json.reference_answer }}",
+		"{{ item.moreData.b }}",
+		"{{ sample.output_json.moreData.a }}",
+		"",
+		"{{ sample.output_json.moreData.b }}"
+	])
+	print("Copyable data generated")
+	quit(0)


### PR DESCRIPTION
## Summary
- generate copyable data scenes from item and model sample TextEdits
- clean grader list scene and add coverage for generated copyable data

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_copyable_data.gd` *(fails: referenced icons and scripts missing/imported)*


------
https://chatgpt.com/codex/tasks/task_e_68908d7e1278832085751fe6b6eb8910