### PR TITLE
Allow text final message for RFT

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -323,13 +323,13 @@ func convert_rft_data(ftdata):
 		var conversation = ftdata['conversations'][conversation_key].duplicate(true)
 		# For reinforcement fine tuning, we need to remove the last assistant message/function call, because we need to convert it to "correct data"
 		var last_message = conversation.pop_back()
-		# We need to check if the message we got is assistant + either JSON Schema or function call
+		# We need to check if the message we got is assistant + either JSON Schema, function call, or plain text
 		if last_message['role'] != "assistant":
 			print("Invalid role in last message in conversation " + conversation_key + ", skipping...")
 			print("Last message:")
 			print(last_message)
 			continue
-		if last_message['type'] != "JSON Schema" and last_message['type'] != "Function Call":
+		if last_message['type'] != "JSON Schema" and last_message['type'] != "Function Call" and last_message['type'] != "Text":
 			print("Invalid type in last message in conversation " + conversation_key + ", skipping...")
 			continue
 		var correct_data = {}
@@ -345,6 +345,10 @@ func convert_rft_data(ftdata):
 				"arguments": get_parameter_values_from_function_parameter_dict(last_message["functionParameters"]),
 				"functionUsePreText": last_message["functionUsePreText"]
 			}
+		elif last_message['type'] == "Text":
+			correct_data['ideal_function_call_data'] = []
+			correct_data['do_function_call'] = false
+			correct_data['reference_answer'] = last_message.get("textContent", "")
 		else:
 			print("Something went very wrong...")
 			continue

--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -110,9 +110,9 @@ func _on_grader_validation_completed(response: Dictionary) -> void:
 	if response.has("error"):
 		error_label.text = response.get("error", {}).get("message", "")
 		error_label.visible = true
-	_status_label.text = tr("GRADER_VERIFICATION_ERROR")
-	_set_grader_controls_disabled(true)
-	_use_button.button_pressed = false
+		_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+		_set_grader_controls_disabled(true)
+		_use_button.button_pressed = false
 	else:
 		error_label.text = ""
 		error_label.visible = false
@@ -130,8 +130,8 @@ func _on_grader_validation_completed(response: Dictionary) -> void:
 					item = _parse_json_or_string(item_node.text)
 			_grader.run_grader(_last_grader_data, model_sample, item)
 		else:
-		       _status_label.text = tr("GRADER_VERIFIED")
-		       _set_grader_controls_disabled(false)
+			_status_label.text = tr("GRADER_VERIFIED")
+			_set_grader_controls_disabled(false)
 
 func _on_grader_run_completed(response: Dictionary) -> void:
 	print(response)
@@ -140,9 +140,9 @@ func _on_grader_run_completed(response: Dictionary) -> void:
 	if response.has("error"):
 		error_label.text = response.get("error", {}).get("message", "")
 		error_label.visible = true
-	_status_label.text = tr("GRADER_VERIFICATION_ERROR")
-	_set_grader_controls_disabled(true)
-	_use_button.button_pressed = false
+		_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+		_set_grader_controls_disabled(true)
+		_use_button.button_pressed = false
 		return
 	var errors = response.get("metadata", {}).get("errors", {})
 	var messages: Array[String] = []
@@ -156,15 +156,15 @@ func _on_grader_run_completed(response: Dictionary) -> void:
 	if messages.size() > 0:
 		error_label.text = "; ".join(messages)
 		error_label.visible = true
-	_status_label.text = tr("GRADER_VERIFICATION_ERROR")
-	_set_grader_controls_disabled(true)
-	_use_button.button_pressed = false
+		_status_label.text = tr("GRADER_VERIFICATION_ERROR")
+		_set_grader_controls_disabled(true)
+		_use_button.button_pressed = false
 	else:
 		error_label.text = ""
 		error_label.visible = false
 		var reward = response.get("reward", 0)
-	_status_label.text = "%s (%.3f)" % [tr("GRADER_VERIFIED"), reward]
-	_set_grader_controls_disabled(false)
+		_status_label.text = "%s (%.3f)" % [tr("GRADER_VERIFIED"), reward]
+		_set_grader_controls_disabled(false)
 
 func _on_verify_timeout() -> void:
 	verify_grader()
@@ -200,7 +200,7 @@ func _connect_gui_input_signals(node: Node) -> void:
 	if not node.is_connected("child_entered_tree", Callable(self, "_on_child_entered")):
 		node.connect("child_entered_tree", Callable(self, "_on_child_entered"))
 	for child in node.get_children():
-	_connect_gui_input_signals(child)
+		_connect_gui_input_signals(child)
 
 func _set_grader_controls_disabled(disabled: bool) -> void:
 	_use_button.disabled = disabled

--- a/src/tests/test_rft_text_export.gd
+++ b/src/tests/test_rft_text_export.gd
@@ -1,0 +1,57 @@
+extends SceneTree
+
+class DummyFineTune:
+	extends Node
+	var SETTINGS = {"includeFunctions": 0}
+	func update_settings_internal():
+		pass
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var ft = DummyFineTune.new()
+	ft.name = "FineTune"
+	get_root().add_child(ft)
+	var exporter = load("res://scenes/exporter.gd").new()
+	get_root().add_child(exporter)
+	var ftdata = {
+		"functions": [],
+		"settings": {},
+		"conversations": {
+			"c1": [
+				{"role": "user", "type": "Text", "textContent": "Hi"},
+				{"role": "assistant", "type": "Text", "textContent": "Hello"}
+			],
+			"c2": [
+				{"role": "user", "type": "Text", "textContent": "Add"},
+				{
+					"role": "assistant",
+					"type": "Function Call",
+					"functionName": "add",
+					"functionUsePreText": "",
+					"functionParameters": [
+						{"name": "a", "isUsed": true, "parameterValueChoice": "", "parameterValueText": "2", "parameterValueNumber": 0},
+						{"name": "b", "isUsed": true, "parameterValueChoice": "", "parameterValueText": "3", "parameterValueNumber": 0}
+					],
+					"functionResults": ""
+				}
+			],
+			"c3": [
+				{"role": "user", "type": "Text", "textContent": "Schema"},
+				{"role": "assistant", "type": "JSON Schema", "jsonSchemaValue": "{\"foo\": \"bar\"}"}
+			]
+		}
+	}
+	var result = await exporter.convert_rft_data(ftdata)
+	var lines = result.strip_edges().split("\n")
+	var parsed1 = JSON.parse_string(lines[0])
+	assert(parsed1.get("reference_answer", "") == "Hello")
+	var parsed2 = JSON.parse_string(lines[1])
+	assert(parsed2.get("do_function_call", false))
+	assert(parsed2.get("ideal_function_call_data", {}).get("name", "") == "add")
+	var parsed3 = JSON.parse_string(lines[2])
+	assert(parsed3.get("foo", "") == "bar")
+	assert(parsed3.get("do_function_call", true) == false)
+	print("RFT export variants ok")
+	quit(0)


### PR DESCRIPTION
## Summary
- support plain text as the final assistant message in RFT exports and store it in `reference_answer`
- add regression tests ensuring RFT export handles text, function call, and JSON Schema endings
- correct grader container indentation to eliminate parse errors during validation and run completion

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s res://tests/openai_import_test.gd`
- `godot --headless --path src -s res://tests/test_application_start.gd`
- `godot --headless --path src -s res://tests/test_copyable_data.gd` *(fails: Assertion failed)*
- `godot --headless --path src -s res://tests/test_grader.gd`
- `godot --headless --path src -s res://tests/test_import_openai.gd`
- `godot --headless --path src -s res://tests/test_load_examples.gd`
- `godot --headless --path src -s res://tests/test_rft_text_export.gd`


------
https://chatgpt.com/codex/tasks/task_e_6891416f462883209ae9510470a82a3b