### PR TITLE
Fix image export honoring 'as given' setting

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -129,12 +129,8 @@ func convert_message_to_openai_format(message, function_map=null):
 		var begins_with_http = image_content.begins_with("http://") or image_content.begins_with("https://")
 
 		if getSettings().get('exportImagesHow', 0) == 0:
-			if isImageURL(image_content):
+			if begins_with_http:
 				image_url_data = image_content
-			elif begins_with_http:
-				var base64_data = await url_to_base64(image_content)
-				var ext = get_ext_from_base64(base64_data)
-				image_url_data = "data:image/%s;base64,%s" % [ext, base64_data]
 			else:
 				var ext = get_ext_from_base64(image_content)
 				image_url_data = "data:image/%s;base64,%s" % [ext, image_content]

--- a/src/tests/test_image_url_export.gd
+++ b/src/tests/test_image_url_export.gd
@@ -1,0 +1,39 @@
+extends SceneTree
+
+class DummyFineTune:
+	extends Node
+	var SETTINGS = {"exportImagesHow": 0}
+	func update_settings_internal():
+		pass
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var ft = DummyFineTune.new()
+	ft.name = "FineTune"
+	get_root().add_child(ft)
+	var exporter = load("res://scenes/exporter.gd").new()
+	get_root().add_child(exporter)
+	var msg_url = {
+		"type": "Image",
+		"role": "user",
+		"imageContent": "http://example.com/test.png",
+		"imageDetail": 0
+	}
+	var res_url = await exporter.convert_message_to_openai_format(msg_url)
+	var url = res_url.get("content", [])[0].get("image_url", {}).get("url", "")
+	assert(url == "http://example.com/test.png")
+
+	var b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+	var msg_b64 = {
+		"type": "Image",
+		"role": "user",
+		"imageContent": b64,
+		"imageDetail": 0
+	}
+	var res_b64 = await exporter.convert_message_to_openai_format(msg_b64)
+	var url_b64 = res_b64.get("content", [])[0].get("image_url", {}).get("url", "")
+	assert(url_b64.begins_with("data:image/"))
+	print("Image export respects 'as given'")
+	quit(0)


### PR DESCRIPTION
## Summary
- keep image URLs when "exportImagesHow" is set to export as given
- add regression test for exporting image URLs

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_rft_text_export.gd`
- `godot --headless --path src -s tests/test_image_url_export.gd`


------
https://chatgpt.com/codex/tasks/task_e_68928d5081208320b42aeeba8213e393