### PR TITLE
Extend sample copyable data to include JSON and tools

### DIFF
--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -55,7 +55,10 @@ func _update_copyable_data():
 	json = JSON.new()
 	var model_text = container.get_node("SampleModelOutputEdit").text
 	if json.parse(model_text) == OK:
-		_collect_paths("sample.output_json.reference_json", json.data, model_paths)
+		model_paths.append("{{ sample.output_json }}")
+		_collect_paths("sample.output_json", json.data, model_paths)
+	model_paths.append("{{ sample.output_tools }}")
+	model_paths.append("{{ sample.output_tools[0].function.name }}")
 	var max_len = max(item_paths.size(), model_paths.size())
 	for i in range(max_len):
 		var item_inst = COPYABLE_SCENE.instantiate()

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -17,15 +17,15 @@ func _run():
 	for i in range(4, container.get_child_count()):
 		datas.append(container.get_child(i).dataStr)
 	datas = datas.slice(2, datas.size())
-	assert(datas == [
-				"{{ item.reference_json.reference_answer }}",
-				"{{ sample.output_text }}",
-				"{{ item.reference_json.moreData.a }}",
-				"{{ sample.output_json.reference_json.reference_answer }}",
-				"{{ item.reference_json.moreData.b }}",
-				"{{ sample.output_json.reference_json.moreData.a }}",
-				"",
-		"{{ sample.output_json.reference_json.moreData.b }}"
-])
+	assert(datas.has("{{ sample.output_text }}"))
+	assert(datas.has("{{ sample.output_json }}"))
+	assert(datas.has("{{ sample.output_json.reference_answer }}"))
+	assert(datas.has("{{ sample.output_json.moreData.a }}"))
+	assert(datas.has("{{ sample.output_json.moreData.b }}"))
+	assert(datas.has("{{ sample.output_tools }}"))
+	assert(datas.has("{{ sample.output_tools[0].function.name }}"))
+	assert(datas.has("{{ item.reference_json.reference_answer }}"))
+	assert(datas.has("{{ item.reference_json.moreData.a }}"))
+	assert(datas.has("{{ item.reference_json.moreData.b }}"))
 	print("Copyable data generated")
 	quit(0)


### PR DESCRIPTION
## Summary
- expose sample output JSON and tool call paths in copyable data
- add tests verifying new sample namespaces

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_copyable_data.gd`


------
https://chatgpt.com/codex/tasks/task_e_6893a24ae9dc83208db6f0be8d76ac54