### PR TITLE
Fix sample text removal in graders list

### DIFF
--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -44,7 +44,8 @@ func from_var(graders_data):
 
 func _update_copyable_data():
 	var container = $GradersListContainer/SampleItemsContainer
-	for i in range(container.get_child_count() - 1, 3, -1):
+	var last_static_index = container.get_node("SampleModelOutputEdit").get_index()
+	for i in range(container.get_child_count() - 1, last_static_index, -1):
 		container.get_child(i).queue_free()
 	var item_paths = []
 	var item_text = container.get_node("SampleItemTextEdit").text


### PR DESCRIPTION
## Summary
- Keep sample text fields when building list of copyable paths

## Testing
- `godot --headless --path src -s res://tests/test_grader.gd`
- `godot --headless --path src -s res://tests/test_grader_item_wrap.gd` *(fails: Unable to open file: res://.godot/imported/help-circle-outline-custom.png-342375c8503c45c2b128316224aa1035.ctex)*


------
https://chatgpt.com/codex/tasks/task_e_6895ced1e12883209656ee99d570bb15