### PR TITLE
feat: add model output sample conversion

### DIFF
--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -1107,5 +1107,25 @@ func to_rft_reference_item():
 		correct_data["reference_answer"] = last_message.get("textContent", "")
 	return {"reference_json": correct_data}
 
+func to_model_output_sample():
+	var msg = to_var()
+	var sample = {"tool_calls": []}
+	if msg.get("type", "") == "Text":
+		sample["sample_text"] = msg.get("textContent", "")
+	elif msg.get("type", "") == "Function Call":
+		sample["sample_text"] = msg.get("functionUsePreText", "")
+		var args = get_parameter_values_from_function_parameter_dict(msg.get("functionParameters", []))
+		sample["tool_calls"].append({
+			"id": "call_0",
+			"type": "function",
+			"function": {
+				"name": msg.get("functionName", ""),
+				"arguments": JSON.stringify(args)
+			}
+		})
+	elif msg.get("type", "") == "JSON Schema":
+		sample["output_json"] = JSON.parse_string(msg.get("jsonSchemaValue", "{}"))
+	return sample
+
 func _on_button_pressed() -> void:
 	print(to_rft_reference_item())

--- a/src/tests/test_model_output_sample.gd
+++ b/src/tests/test_model_output_sample.gd
@@ -1,0 +1,56 @@
+extends SceneTree
+
+var tests_run := 0
+var tests_failed := 0
+
+func assert_eq(a, b, name := ""):
+	tests_run += 1
+	if a != b:
+		tests_failed += 1
+		push_error("Assertion failed %s: expected %s got %s" % [name, str(b), str(a)])
+
+func test_text_message():
+	var Scene = load("res://scenes/message.tscn")
+	var node = Scene.instantiate()
+	node.from_var({"role":"assistant","type":"Text","textContent":"Hello"})
+	var sample = node.to_model_output_sample()
+	assert_eq(sample.get("sample_text", ""), "Hello", "sample_text")
+	assert_eq(sample.get("tool_calls", []).size(), 0, "no tool calls")
+	node.queue_free()
+
+func test_function_call():
+	var Scene = load("res://scenes/message.tscn")
+	var node = Scene.instantiate()
+	node.from_var({
+		"role":"assistant",
+		"type":"Function Call",
+		"functionName":"add",
+		"functionUsePreText":"",
+		"functionParameters":[{"name":"a","isUsed":true,"parameterValueChoice":"","parameterValueText":"2","parameterValueNumber":0}],
+		"functionResults":""
+	})
+	var sample = node.to_model_output_sample()
+	assert_eq(sample.get("tool_calls", []).size(), 1, "tool call size")
+	assert_eq(sample.get("tool_calls", [])[0]["function"]["name"], "add", "function name")
+	var args = JSON.parse_string(sample.get("tool_calls", [])[0]["function"]["arguments"])
+	assert_eq(args.get("a", ""), "2", "argument a")
+	node.queue_free()
+
+func test_json_schema():
+	var Scene = load("res://scenes/message.tscn")
+	var node = Scene.instantiate()
+	node.from_var({
+		"role":"assistant",
+		"type":"JSON Schema",
+		"jsonSchemaValue":"{\"foo\":\"bar\"}"
+	})
+	var sample = node.to_model_output_sample()
+	assert_eq(sample.get("output_json", {}).get("foo", ""), "bar", "output_json")
+	node.queue_free()
+
+func _init():
+	test_text_message()
+	test_function_call()
+	test_json_schema()
+	print("Tests run: %d, Failures: %d" % [tests_run, tests_failed])
+	quit(tests_failed)

--- a/src/tests/test_model_output_sample.gd.uid
+++ b/src/tests/test_model_output_sample.gd.uid
@@ -1,0 +1,1 @@
+uid://c22jd4rxy0an8


### PR DESCRIPTION
## Summary
- add `to_model_output_sample` to message scene to build model output sample structures with text, tool calls, or JSON payloads
- cover functionality with a dedicated test

## Testing
- `godot --headless --path src -s tests/test_model_output_sample.gd` *(fails: File Access Web worked only for HTML5 platform export!)*


------
https://chatgpt.com/codex/tasks/task_e_6895cdae3b748320acadba12fba60da3