### PR TITLE
Auto-fill grader sample fields from last conversation message

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -216,6 +216,7 @@ func _on_item_list_item_selected(index: int) -> void:
 	print(CURRENT_EDITED_CONVO_IX)
 	DisplayServer.window_set_title("finetune-collect - Current conversation: " + CURRENT_EDITED_CONVO_IX)
 	$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[str(CURRENT_EDITED_CONVO_IX)])
+	$Conversation/Graders/GradersList.update_from_last_message()
 	
 
 

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -14,9 +14,8 @@ func _run():
 	model_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
 	scene._update_copyable_data()
 	var datas = []
-	for i in range(4, container.get_child_count()):
+	for i in range(6, container.get_child_count()):
 		datas.append(container.get_child(i).dataStr)
-	datas = datas.slice(2, datas.size())
 	assert(datas.has("{{ sample.output_text }}"))
 	assert(datas.has("{{ sample.output_json }}"))
 	assert(datas.has("{{ sample.output_json.reference_answer }}"))

--- a/src/tests/test_grader_item_wrap.gd
+++ b/src/tests/test_grader_item_wrap.gd
@@ -1,22 +1,33 @@
 extends SceneTree
 
 class GraderStub:
-	extends Node
-	signal run_completed(response)
-	signal validation_completed(response)
+	extends "res://addons/openai_api/Scripts/Grader.gd"
 	var last_item = null
-	func run_grader(grader, model_sample, item):
+	func run_grader(grader: Dictionary, model_sample, item = null, url: String = ""):
 		last_item = item
-	func validate_grader(grader):
+	func validate_grader(grader: Dictionary, url: String = ""):
 		pass
 
 class OpenAiStub:
 	extends Node
+	signal gpt_response_completed(message, response)
+	signal models_received(models)
 	var grader_stub := GraderStub.new()
 	func create_grader():
 		return grader_stub
 	func get_api():
 		return ""
+	func get_models():
+		pass
+
+class MessageStub:
+	extends Node
+	func to_rft_reference_item():
+		return {"reference_json": {"ideal_function_call_data": [], "do_function_call": false, "reference_answer": "fuzzy wuzzy was a bear"}}
+	func to_model_output_sample():
+		return {"tool_calls": [], "sample_text": "fuzzy wuzzy was a bear"}
+	func to_var():
+		return {"type": "Text"}
 
 func _init():
 	call_deferred("_run")
@@ -25,25 +36,39 @@ func _run():
 	var fineTune = Node.new()
 	fineTune.name = "FineTune"
 	var openai_stub = OpenAiStub.new()
+	openai_stub.name = "OpenAi"
 	fineTune.add_child(openai_stub)
+	var conversation = Node.new()
+	conversation.name = "Conversation"
+	var messages = Node.new()
+	messages.name = "Messages"
+	var messages_list = Node.new()
+	messages_list.name = "MessagesList"
+	var messages_container = Node.new()
+	messages_container.name = "MessagesListContainer"
+	messages_list.add_child(messages_container)
+	messages.add_child(messages_list)
+	var graders = Node.new()
+	graders.name = "Graders"
+	var graders_list = load("res://scenes/graders/graders_list.tscn").instantiate()
+	graders_list.name = "GradersList"
+	graders.add_child(graders_list)
+	conversation.add_child(messages)
+	conversation.add_child(graders)
+	fineTune.add_child(conversation)
 	get_root().add_child(fineTune)
-
-	var scene = load("res://scenes/graders/graders_list.tscn").instantiate()
-	get_root().add_child(scene)
 	await create_timer(0).timeout
-
-	scene._on_add_grader_button_pressed()
-	var graders_container = scene.get_node("GradersListContainer")
+	var msg = MessageStub.new()
+	messages_container.add_child(msg)
+	graders_list.update_from_last_message()
+	graders_list._on_add_grader_button_pressed()
+	var graders_container = graders_list.get_node("GradersListContainer")
 	var gc = null
 	for child in graders_container.get_children():
 		if child.name != "AddGraderButton" and child.name != "SampleItemsContainer":
 			gc = child
 			break
-
-	scene.get_node("GradersListContainer/SampleItemsContainer/SampleItemTextEdit").text = '{"reference_answer": "fuzzy wuzzy was a bear"}'
-	scene.get_node("GradersListContainer/SampleItemsContainer/SampleModelOutputEdit").text = 'fuzzy wuzzy was a bear'
 	gc._last_grader_data = {"type": "string_check"}
-
 	gc._on_grader_validation_completed({})
 	var wrapped = openai_stub.grader_stub.last_item
 	assert(wrapped.get("reference_json", {}).get("reference_answer", "") == "fuzzy wuzzy was a bear")


### PR DESCRIPTION
## Summary
- Auto-populate grader reference and sample fields with the last message of the current conversation
- Refresh grader samples on tab switch or conversation change and re-run graders unless the last message is a function call
- Update tests for new automatic sample behavior

## Testing
- `godot --headless -s tests/test_copyable_data.gd`
- `godot --headless -s tests/test_grader_item_wrap.gd`
- `godot --headless -s tests/test_model_output_sample.gd` *(fails: Node not found: "/root/FineTune")*

------
https://chatgpt.com/codex/tasks/task_e_689626fec6c0832096c9263015fa5a37