### PR TITLE
Refactor sample and reference fields for grader items

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -328,11 +328,12 @@ func convert_rft_data(ftdata):
 		if last_message['type'] != "JSON Schema" and last_message['type'] != "Function Call" and last_message['type'] != "Text":
 			print("Invalid type in last message in conversation " + conversation_key + ", skipping...")
 			continue
-		var reference_data = {}
+		var reference_json = {}
+		var reference_answer = ""
 		var do_function_call = false
 		var ideal_function_call_data = []
 		if last_message['type'] == "JSON Schema":
-			reference_data = JSON.parse_string(last_message['jsonSchemaValue'])
+			reference_json = JSON.parse_string(last_message['jsonSchemaValue'])
 		elif last_message['type'] == "Function Call":
 			do_function_call = true
 			ideal_function_call_data = {
@@ -341,7 +342,7 @@ func convert_rft_data(ftdata):
 				"functionUsePreText": last_message["functionUsePreText"]
 			}
 		elif last_message['type'] == "Text":
-			reference_data["reference_answer"] = last_message.get("textContent", "")
+			reference_answer = last_message.get("textContent", "")
 		else:
 			print("Something went very wrong...")
 			continue
@@ -357,7 +358,8 @@ func convert_rft_data(ftdata):
 		processed_conversation += await convert_conversation_to_openai_format(conversation, function_map)
 		# Write to JSONL, optionally including tools
 		var output_entry = {}
-		output_entry['reference_json'] = reference_data
+		output_entry['reference_json'] = reference_json
+		output_entry['reference_answer'] = reference_answer
 		output_entry['do_function_call'] = do_function_call
 		output_entry['ideal_function_call_data'] = ideal_function_call_data
 		output_entry['messages'] = processed_conversation

--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -128,8 +128,6 @@ func _on_grader_validation_completed(response: Dictionary) -> void:
 				var item_node = list_container.get_node_or_null("SampleItemsContainer/SampleItemTextEdit")
 				if item_node:
 					item = _parse_json_or_string(item_node.text)
-					if item is Dictionary and not item.has("reference_json"):
-						item = {"reference_json": item}
 			_grader.run_grader(_last_grader_data, model_sample, item)
 		else:
 			_status_label.text = tr("GRADER_VERIFIED")

--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -88,7 +88,7 @@ func _update_copyable_data():
 	var item_text = container.get_node("SampleItemTextEdit").text
 	var json = JSON.new()
 	if json.parse(item_text) == OK:
-		_collect_paths("item.reference_json", json.data, item_paths)
+		_collect_paths("item", json.data, item_paths)
 	var model_paths = ["{{ sample.output_text }}"]
 	json = JSON.new()
 	var model_text = container.get_node("SampleModelOutputEdit").text

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -1086,17 +1086,14 @@ func get_parameter_values_from_function_parameter_dict(fpdict):
 
 func to_rft_reference_item():
 	var last_message = to_var()
-	var reference_data = {}
 	var item = {
-		"reference_json": reference_data,
 		"ideal_function_call_data": [],
 		"do_function_call": false
 	}
 	if last_message.get("role", "") != "assistant":
 		return item
 	if last_message.get("type", "") == "JSON Schema":
-		reference_data = JSON.parse_string(last_message.get("jsonSchemaValue", "{}"))
-		item["reference_json"] = reference_data
+		item["reference_json"] = JSON.parse_string(last_message.get("jsonSchemaValue", "{}"))
 	elif last_message.get("type", "") == "Function Call":
 		item["do_function_call"] = true
 		item["ideal_function_call_data"] = {
@@ -1105,19 +1102,18 @@ func to_rft_reference_item():
 					"functionUsePreText": last_message.get("functionUsePreText", "")
 			}
 	elif last_message.get("type", "") == "Text":
-			reference_data["reference_answer"] = last_message.get("textContent", "")
-			item["reference_json"] = reference_data
+			item["reference_answer"] = last_message.get("textContent", "")
 	return item
 
 func to_model_output_sample():
 	var msg = to_var()
-	var sample = {"tool_calls": []}
+	var sample = {"output_tools": []}
 	if msg.get("type", "") == "Text":
-		sample["sample_text"] = msg.get("textContent", "")
+		sample["output_text"] = msg.get("textContent", "")
 	elif msg.get("type", "") == "Function Call":
-		sample["sample_text"] = msg.get("functionUsePreText", "")
+		sample["output_text"] = msg.get("functionUsePreText", "")
 		var args = get_parameter_values_from_function_parameter_dict(msg.get("functionParameters", []))
-		sample["tool_calls"].append({
+		sample["output_tools"].append({
 			"id": "call_0",
 			"type": "function",
 			"function": {

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -10,7 +10,7 @@ func _run():
 	var container = scene.get_node("GradersListContainer/SampleItemsContainer")
 	var item_edit = container.get_node("SampleItemTextEdit")
 	var model_edit = container.get_node("SampleModelOutputEdit")
-	item_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
+	item_edit.text = '{"do_function_call": false, "ideal_function_call_data": [], "reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
 	model_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
 	scene._update_copyable_data()
 	var datas = []
@@ -23,8 +23,9 @@ func _run():
 	assert(datas.has("{{ sample.output_json.moreData.b }}"))
 	assert(datas.has("{{ sample.output_tools }}"))
 	assert(datas.has("{{ sample.output_tools[0].function.name }}"))
-	assert(datas.has("{{ item.reference_json.reference_answer }}"))
-	assert(datas.has("{{ item.reference_json.moreData.a }}"))
-	assert(datas.has("{{ item.reference_json.moreData.b }}"))
+	assert(datas.has("{{ item.reference_answer }}"))
+	assert(datas.has("{{ item.moreData.a }}"))
+	assert(datas.has("{{ item.moreData.b }}"))
+	assert(datas.has("{{ item.do_function_call }}"))
 	print("Copyable data generated")
 	quit(0)

--- a/src/tests/test_grader_item_wrap.gd
+++ b/src/tests/test_grader_item_wrap.gd
@@ -23,9 +23,9 @@ class OpenAiStub:
 class MessageStub:
 	extends Node
 	func to_rft_reference_item():
-		return {"reference_json": {"reference_answer": "fuzzy wuzzy was a bear"}, "ideal_function_call_data": [], "do_function_call": false}
+		return {"reference_answer": "fuzzy wuzzy was a bear", "ideal_function_call_data": [], "do_function_call": false}
 	func to_model_output_sample():
-		return {"tool_calls": [], "sample_text": "fuzzy wuzzy was a bear"}
+		return {"output_tools": [], "output_text": "fuzzy wuzzy was a bear"}
 	func to_var():
 		return {"type": "Text"}
 
@@ -71,6 +71,6 @@ func _run():
 	gc._last_grader_data = {"type": "string_check"}
 	gc._on_grader_validation_completed({})
 	var wrapped = openai_stub.grader_stub.last_item
-	assert(wrapped.get("reference_json", {}).get("reference_answer", "") == "fuzzy wuzzy was a bear")
-	print("Grader wraps item reference_json")
+	assert(wrapped.get("reference_answer", "") == "fuzzy wuzzy was a bear")
+	print("Grader wraps item reference answer")
 	quit(0)

--- a/src/tests/test_model_output_sample.gd
+++ b/src/tests/test_model_output_sample.gd
@@ -14,8 +14,8 @@ func test_text_message():
 	var node = Scene.instantiate()
 	node.from_var({"role":"assistant","type":"Text","textContent":"Hello"})
 	var sample = node.to_model_output_sample()
-	assert_eq(sample.get("sample_text", ""), "Hello", "sample_text")
-	assert_eq(sample.get("tool_calls", []).size(), 0, "no tool calls")
+	assert_eq(sample.get("output_text", ""), "Hello", "output_text")
+	assert_eq(sample.get("output_tools", []).size(), 0, "no tool calls")
 	node.queue_free()
 
 func test_function_call():
@@ -30,9 +30,9 @@ func test_function_call():
 		"functionResults":""
 	})
 	var sample = node.to_model_output_sample()
-	assert_eq(sample.get("tool_calls", []).size(), 1, "tool call size")
-	assert_eq(sample.get("tool_calls", [])[0]["function"]["name"], "add", "function name")
-	var args = JSON.parse_string(sample.get("tool_calls", [])[0]["function"]["arguments"])
+	assert_eq(sample.get("output_tools", []).size(), 1, "tool call size")
+	assert_eq(sample.get("output_tools", [])[0]["function"]["name"], "add", "function name")
+	var args = JSON.parse_string(sample.get("output_tools", [])[0]["function"]["arguments"])
 	assert_eq(args.get("a", ""), "2", "argument a")
 	node.queue_free()
 

--- a/src/tests/test_rft_text_export.gd
+++ b/src/tests/test_rft_text_export.gd
@@ -46,7 +46,7 @@ func _run():
 	var result = await exporter.convert_rft_data(ftdata)
 	var lines = result.strip_edges().split("\n")
 	var parsed1 = JSON.parse_string(lines[0])
-	assert(parsed1.get("reference_json", {}).get("reference_answer", "") == "Hello")
+	assert(parsed1.get("reference_answer", "") == "Hello")
 	assert(parsed1.get("do_function_call", true) == false)
 	var parsed2 = JSON.parse_string(lines[1])
 	assert(parsed2.get("do_function_call", false))


### PR DESCRIPTION
## Summary
- expose `reference_answer` as a top-level field when creating grader items and exports
- rename model output sample fields to `output_text`/`output_tools`
- generate copyable paths directly under `item` without `reference_json` prefix

## Testing
- `godot --headless --path src -s tests/test_copyable_data.gd`
- `godot --headless --path src -s tests/test_grader_item_wrap.gd`
- `godot --headless --path src -s tests/test_rft_text_export.gd`
- `godot --headless --path src -s tests/test_model_output_sample.gd` *(fails: File Access Web worked only for HTML5 platform export)*

------
https://chatgpt.com/codex/tasks/task_e_689651dd0f60832088f880560cbf95da