### PR TITLE
Ensure sample output text handling

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -124,7 +124,11 @@ func _on_grader_validation_completed(response: Dictionary) -> void:
 			if list_container:
 				var model_node = list_container.get_node_or_null("SampleItemsContainer/SampleModelOutputEdit")
 				if model_node:
-					model_sample = str(_parse_json_or_string(model_node.text))
+					var json = JSON.new()
+					if json.parse(model_node.text) == OK and json.data is Dictionary:
+						model_sample = str(json.data.get("output_text", ""))
+					else:
+						model_sample = model_node.text
 				var item_node = list_container.get_node_or_null("SampleItemsContainer/SampleItemTextEdit")
 				if item_node:
 					item = _parse_json_or_string(item_node.text)

--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -93,10 +93,15 @@ func _update_copyable_data():
 	json = JSON.new()
 	var model_text = container.get_node("SampleModelOutputEdit").text
 	if json.parse(model_text) == OK:
-		model_paths.append("{{ sample.output_json }}")
-		_collect_paths("sample.output_json", json.data, model_paths)
-	model_paths.append("{{ sample.output_tools }}")
-	model_paths.append("{{ sample.output_tools[0].function.name }}")
+		var sample_data = json.data
+		var out_json = sample_data.get("output_json")
+		if out_json is Dictionary or out_json is Array:
+			model_paths.append("{{ sample.output_json }}")
+			_collect_paths("sample.output_json", out_json, model_paths)
+		var out_tools = sample_data.get("output_tools")
+		if out_tools is Array:
+			model_paths.append("{{ sample.output_tools }}")
+			_collect_paths("sample.output_tools", out_tools, model_paths)
 	var max_len = max(item_paths.size(), model_paths.size())
 	for i in range(max_len):
 		var item_inst = COPYABLE_SCENE.instantiate()

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -1108,21 +1108,29 @@ func to_rft_reference_item():
 func to_model_output_sample():
 	var msg = to_var()
 	var sample = {"output_tools": []}
-	if msg.get("type", "") == "Text":
-		sample["output_text"] = msg.get("textContent", "")
-	elif msg.get("type", "") == "Function Call":
-		sample["output_text"] = msg.get("functionUsePreText", "")
-		var args = get_parameter_values_from_function_parameter_dict(msg.get("functionParameters", []))
-		sample["output_tools"].append({
-			"id": "call_0",
-			"type": "function",
-			"function": {
-				"name": msg.get("functionName", ""),
-				"arguments": JSON.stringify(args)
-			}
-		})
-	elif msg.get("type", "") == "JSON Schema":
-		sample["output_json"] = JSON.parse_string(msg.get("jsonSchemaValue", "{}"))
+	var text := ""
+	match msg.get("type", ""):
+		"Text":
+			text = msg.get("textContent", "")
+		"Function Call":
+			text = msg.get("functionUsePreText", "")
+			var args = get_parameter_values_from_function_parameter_dict(msg.get("functionParameters", []))
+			sample["output_tools"].append({
+				"id": "call_0",
+				"type": "function",
+				"function": {
+					"name": msg.get("functionName", ""),
+					"arguments": JSON.stringify(args)
+				}
+			})
+		"JSON Schema":
+			text = msg.get("jsonSchemaValue", "")
+		_:
+			text = msg.get("textContent", "")
+	sample["output_text"] = text
+	var parsed = JSON.parse_string(text)
+	if parsed != null and (parsed is Dictionary or parsed is Array):
+		sample["output_json"] = parsed
 	return sample
 
 func _on_button_pressed() -> void:

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -11,7 +11,7 @@ func _run():
 	var item_edit = container.get_node("SampleItemTextEdit")
 	var model_edit = container.get_node("SampleModelOutputEdit")
 	item_edit.text = '{"do_function_call": false, "ideal_function_call_data": [], "reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
-	model_edit.text = '{"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
+	model_edit.text = '{"output_text": "fuzzy", "output_json": {"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}, "output_tools": [{"id": "call_0", "type": "function", "function": {"name": "foo"}}]}'
 	scene._update_copyable_data()
 	var datas = []
 	for i in range(6, container.get_child_count()):


### PR DESCRIPTION
## Summary
- Always populate `output_text` as a string when building model output samples, and send only that string to the grader API
- Improve copyable data generation to avoid duplicate `output_json` paths and rely on JSON for tool placeholders
- Update copyable data test to exercise new JSON/tool path behavior

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --script tests/test_copyable_data.gd`
- `godot --headless --path src --script tests/test_grader_item_wrap.gd`
- `godot --headless --path src --script tests/test_model_output_sample.gd` *(fails: File Access Web worked only for HTML5 platform export!)*

------
https://chatgpt.com/codex/tasks/task_e_68966d24af5083209d0c5710a756cf3a