### PR TITLE
Update grader data when selecting conversation on load

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -495,7 +495,9 @@ func load_from_binary(filename):
 			$Conversation/Graders/GradersList.from_var(GRADERS)
 			$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 			refresh_conversations_list()
-			$VBoxContainer/ConversationsList.select(selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX))
+			var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
+			$VBoxContainer/ConversationsList.select(selected_index)
+			_on_item_list_item_selected(selected_index)
 			call_deferred("_convert_base64_images_after_load")
 	else:
 		print("file not found")
@@ -518,7 +520,9 @@ func load_from_json_data(jsondata: String):
 	$Conversation/Graders/GradersList.from_var(GRADERS)
 	$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 	refresh_conversations_list()
-	$VBoxContainer/ConversationsList.select(selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX))
+	var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
+	$VBoxContainer/ConversationsList.select(selected_index)
+	_on_item_list_item_selected(selected_index)
 	call_deferred("_convert_base64_images_after_load")
 
 func make_save_json_data():


### PR DESCRIPTION
## Summary
- Ensure selecting a conversation after loading a project also updates grader sample data

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_grader.gd`
- `godot --headless --path src -s tests/test_copyable_data.gd` *(fails: missing imported resources)*
- `godot --headless --path src -s tests/test_grader_item_wrap.gd` *(fails: missing imported resources)*
- `python scripts/test-image-upload.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python scripts/test-schema-editor.py` *(no output, had to terminate)*

------
https://chatgpt.com/codex/tasks/task_e_6897342dc23c832098ee70407130b45c