### PR TITLE
Fix accumulating meta messages on auto-load

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -197,18 +197,19 @@ func update_available_functions_in_UI_global():
 			node.add_item(f)
 
 
-func _on_item_list_item_selected(index: int) -> void:
+func _on_item_list_item_selected(index: int, save_before_switch := true) -> void:
 	update_functions_internal()
 	print("Available Function Names:")
 	print(get_available_function_names())
 	print("Functions: ")
 	print(FUNCTIONS)
 	update_available_functions_in_UI_global()
-	save_current_conversation()
+	if save_before_switch:
+		save_current_conversation()
 	# Alle Nachrichten löschen
 	for message in $Conversation/Messages/MessagesList/MessagesListContainer.get_children():
 		if message.is_in_group("message"):
-			message.queue_free()	
+			message.queue_free()
 	# Und die neuen aus der Convo laden
 	CURRENT_EDITED_CONVO_IX = $VBoxContainer/ConversationsList.get_item_tooltip(index)
 	# Create conversation if it does not exist
@@ -217,9 +218,6 @@ func _on_item_list_item_selected(index: int) -> void:
 	DisplayServer.window_set_title("finetune-collect - Current conversation: " + CURRENT_EDITED_CONVO_IX)
 	$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[str(CURRENT_EDITED_CONVO_IX)])
 	$Conversation/Graders/GradersList.update_from_last_message()
-	
-
-
 func save_current_conversation_to_conversations_at_index(ix: int):
 	# THERE SHOULD BE NO REASON TO USE THIS FUNCTION
 	CONVERSATIONS[ix] = $Conversation/Messages/MessagesList.to_var()
@@ -497,7 +495,7 @@ func load_from_binary(filename):
 			refresh_conversations_list()
 			var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
 			$VBoxContainer/ConversationsList.select(selected_index)
-			_on_item_list_item_selected(selected_index)
+			_on_item_list_item_selected(selected_index, false)
 			call_deferred("_convert_base64_images_after_load")
 	else:
 		print("file not found")
@@ -523,9 +521,9 @@ func load_from_json_data(jsondata: String):
 	var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
 	if selected_index == -1:
 		selected_index = len(CONVERSATIONS) - 1 
-	$VBoxContainer/ConversationsList.select(selected_index)
-	_on_item_list_item_selected(selected_index)
-	call_deferred("_convert_base64_images_after_load")
+		$VBoxContainer/ConversationsList.select(selected_index)
+		_on_item_list_item_selected(selected_index, false)
+		call_deferred("_convert_base64_images_after_load")
 
 func make_save_json_data():
 	FINETUNEDATA = {}


### PR DESCRIPTION
## Summary
- allow skipping conversation save when switching selections
- avoid saving conversation while loading projects to prevent duplicate meta messages

## Testing
- `godot --headless --path src --test` *(fails: binary lacks unit-test support)*
- `godot --headless --path src --script tests/test_application_start.gd` *(fails: missing imported resources)*
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68974e3b300c8320911dcbf7924d5be0