### PR TITLE
Move grader controls to top of list

### DIFF
--- a/src/scenes/graders/graders.gd
+++ b/src/scenes/graders/graders.gd
@@ -51,9 +51,8 @@ func update_from_last_message():
 func _on_add_grader_button_pressed() -> void:
 	var inst = GRADER_SCENE.instantiate()
 	$GradersListContainer.add_child(inst)
-	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
-	var btn_index = $GradersListContainer.get_children().find($GradersListContainer/AddGraderButton)
-	$GradersListContainer.move_child(inst, btn_index)
+	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, 0)
+	$GradersListContainer.move_child($GradersListContainer/AddGraderButton, 1)
 
 func to_var():
 	var all = []
@@ -68,14 +67,12 @@ func from_var(graders_data):
 	for child in $GradersListContainer.get_children():
 		if child.name != "AddGraderButton" and child.name != "SampleItemsContainer":
 			child.queue_free()
-	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
+	$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, 0)
+	$GradersListContainer.move_child($GradersListContainer/AddGraderButton, 1)
 	if graders_data is Array:
 		for g in graders_data:
 			var inst = GRADER_SCENE.instantiate()
 			$GradersListContainer.add_child(inst)
-			$GradersListContainer.move_child($GradersListContainer/SampleItemsContainer, -1)
-			var btn_index = $GradersListContainer.get_children().find($GradersListContainer/AddGraderButton)
-			$GradersListContainer.move_child(inst, btn_index)
 			if inst.has_method("from_var"):
 				inst.from_var(g)
 

--- a/src/scenes/graders/graders_list.tscn
+++ b/src/scenes/graders/graders_list.tscn
@@ -18,10 +18,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="AddGraderButton" type="Button" parent="GradersListContainer"]
-layout_mode = 2
-text = "GRADERS_ADD_GRADER_BUTTON_TEXT"
-
 [node name="SampleItemsContainer" type="GridContainer" parent="GradersListContainer"]
 layout_mode = 2
 columns = 2
@@ -57,5 +53,9 @@ text = "{
 custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
 text = "fuzzy wuzzy was a bear"
+
+[node name="AddGraderButton" type="Button" parent="GradersListContainer"]
+layout_mode = 2
+text = "GRADERS_ADD_GRADER_BUTTON_TEXT"
 
 [connection signal="pressed" from="GradersListContainer/AddGraderButton" to="." method="_on_add_grader_button_pressed"]


### PR DESCRIPTION
## Summary
- Move sample item inputs and Add Grader button to top of grader list
- Keep reference item edits and add button pinned at top when adding or loading graders

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_import_openai.gd`
- `godot --headless --path src -s tests/test_model_output_sample.gd` *(fails: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68974f1109d88320a770efb4d229de49