### PR TITLE
Add Python tests for PHP schema validators

### DIFF
--- a/tests/test_schema_align_openai_api.py
+++ b/tests/test_schema_align_openai_api.py
@@ -1,0 +1,54 @@
+import json
+import os
+import subprocess
+import time
+import unittest
+import urllib.request
+
+class SchemaAlignOpenAITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        script = os.path.join(repo_root, "scripts", "schema_align_openai.php")
+        cls.proc = subprocess.Popen(
+            ["php", "-S", "127.0.0.1:8002", script],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            cls.proc.kill()
+
+    def request(self, payload):
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            "http://127.0.0.1:8002/",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+
+    def test_normalization(self):
+        payload = {
+            "schema": {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "additionalProperties": True,
+            }
+        }
+        result = self.request(payload)
+        schema = result["schema"]
+        self.assertEqual(schema["additionalProperties"], False)
+        self.assertEqual(schema["required"], ["a"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_validator_api.py
+++ b/tests/test_schema_validator_api.py
@@ -1,0 +1,72 @@
+import json
+import os
+import subprocess
+import time
+import unittest
+import urllib.request
+
+class SchemaValidatorAPITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        script = os.path.join(repo_root, "scripts", "schema_validator.php")
+        cls.proc = subprocess.Popen(
+            ["php", "-S", "127.0.0.1:8001", script],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            cls.proc.kill()
+
+    def request(self, payload):
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            "http://127.0.0.1:8001/",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+
+    def test_validate_success(self):
+        payload = {
+            "action": "validate",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+            "data": {"name": "Alice"},
+        }
+        result = self.request(payload)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["phase"], "instance")
+
+    def test_validate_failure(self):
+        payload = {
+            "action": "validate",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+            "data": {},
+        }
+        result = self.request(payload)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["phase"], "instance")
+        self.assertGreater(len(result["errors"]), 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python tests for `schema_validator.php`
- add Python tests for `schema_align_openai.php`

## Testing
- `python -m unittest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689df65e9ca88320ab6fce7f9aa21fc1