### PR TITLE
feat: sanitize schema editing

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -1,9 +1,19 @@
 extends HBoxContainer
 
+const SchemaAlignOpenAI := preload("res://scenes/schemas/schema_align_openai.gd")
+
 
 func _on_delete_schema_button_pressed() -> void:
 	queue_free()
 
 
 func _on_edit_json_schema_code_edit_text_changed() -> void:
-	pass # TODO: Automatically set the OAI JSON Schema Edit text to this text but sanitized
+	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
+	var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
+	var json := JSON.new()
+	var err := json.parse(editor.text)
+	if err != OK:
+		oai_editor.text = ""
+		return
+	var sanitized = SchemaAlignOpenAI.sanitize_envelope_or_schema(json.data)
+	oai_editor.text = JSON.stringify(sanitized, "\t")


### PR DESCRIPTION
## Summary
- auto-sanitize JSON schema edits and mirror in OpenAI tab

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_schema_align_openai.gd`
- `godot --headless --path src -s tests/test_application_start.gd` *(fails: resources missing)*


------
https://chatgpt.com/codex/tasks/task_e_689df73a3ccc83208861297a277033d7