### PR TITLE
Enable adding schema containers in Schemas tab

### DIFF
--- a/src/scenes/schemas/schemas.gd
+++ b/src/scenes/schemas/schemas.gd
@@ -1,0 +1,29 @@
+extends ScrollContainer
+
+@onready var SCHEMA_SCENE = preload("res://scenes/schemas/json_schema_container.tscn")
+
+func _on_add_schema_button_pressed() -> void:
+	var inst = SCHEMA_SCENE.instantiate()
+	$SchemasListVBox.add_child(inst)
+	$SchemasListVBox.move_child($SchemasListVBox/AddSchemaButton, -1)
+
+func to_var():
+	var all = []
+	for child in $SchemasListVBox.get_children():
+		if child.name == "AddSchemaButton":
+			continue
+		if child.has_method("to_var"):
+			all.append(child.to_var())
+	return all
+
+func from_var(schemas_data):
+	for child in $SchemasListVBox.get_children():
+		if child.name != "AddSchemaButton":
+			child.queue_free()
+	if schemas_data is Array:
+		for s in schemas_data:
+			var inst = SCHEMA_SCENE.instantiate()
+			$SchemasListVBox.add_child(inst)
+			if inst.has_method("from_var"):
+				inst.from_var(s)
+	$SchemasListVBox.move_child($SchemasListVBox/AddSchemaButton, -1)

--- a/src/scenes/schemas/schemas_list.tscn
+++ b/src/scenes/schemas/schemas_list.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://22jirjovkb2u"]
+[gd_scene load_steps=3 format=3 uid="uid://22jirjovkb2u"]
 
-[ext_resource type="PackedScene" uid="uid://573wf4eeyre0" path="res://scenes/schemas/json_schema_container.tscn" id="1_s6ywv"]
+[ext_resource type="Script" uid="uid://fzuwvedyordh" path="res://scenes/schemas/schemas.gd" id="1_qdfv2"]
+[ext_resource type="PackedScene" uid="uid://573wf4eeyre0" path="res://scenes/schemas/json_schema_container.tscn" id="2_s6ywv"]
 
 [node name="SchemasList" type="ScrollContainer"]
 anchors_preset = 15
@@ -8,6 +9,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_qdfv2")
 
 [node name="SchemasListVBox" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -18,14 +20,4 @@ size_flags_vertical = 3
 layout_mode = 2
 text = "ADD_SCHEMA"
 
-[node name="JSONSchemaContainer" parent="SchemasListVBox" instance=ExtResource("1_s6ywv")]
-layout_mode = 2
-
-[node name="JSONSchemaContainer2" parent="SchemasListVBox" instance=ExtResource("1_s6ywv")]
-layout_mode = 2
-
-[node name="JSONSchemaContainer3" parent="SchemasListVBox" instance=ExtResource("1_s6ywv")]
-layout_mode = 2
-
-[node name="JSONSchemaContainer4" parent="SchemasListVBox" instance=ExtResource("1_s6ywv")]
-layout_mode = 2
+[connection signal="pressed" from="SchemasListVBox/AddSchemaButton" to="." method="_on_add_schema_button_pressed"]


### PR DESCRIPTION
## Summary
- allow adding new schema containers dynamically
- wire up ADD_SCHEMA button in Schemas tab

## Testing
- `bash check_tabs.sh`
- `godot --headless --path src -s tests/test_schema_align_openai.gd`
- `godot --headless --path src -s tests/openai_import_test.gd`


------
https://chatgpt.com/codex/tasks/task_e_689df941d19c8320b7249aaa5ff4c992