### PR TITLE
Sync schema title with name line edit

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -1,9 +1,27 @@
 extends HBoxContainer
 
+@onready var _code_edit: CodeEdit = $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
+@onready var _name_edit: LineEdit = $MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit
+var _updating := false
 
 func _on_delete_schema_button_pressed() -> void:
 	queue_free()
 
-
 func _on_edit_json_schema_code_edit_text_changed() -> void:
-	pass # TODO: Automatically set the OAI JSON Schema Edit text to this text but sanitized
+	if _updating:
+		return
+	var data = JSON.parse_string(_code_edit.text)
+	if data is Dictionary and data.has("title"):
+		_updating = true
+		_name_edit.text = str(data["title"])
+		_updating = false
+
+func _on_schema_name_line_edit_text_changed(new_text: String) -> void:
+	if _updating:
+		return
+	var data = JSON.parse_string(_code_edit.text)
+	if data is Dictionary:
+		data["title"] = new_text
+		_updating = true
+		_code_edit.text = JSON.stringify(data)
+		_updating = false

--- a/src/scenes/schemas/json_schema_container.tscn
+++ b/src/scenes/schemas/json_schema_container.tscn
@@ -153,3 +153,4 @@ editable = false
 
 [connection signal="pressed" from="MarginContainer/JSONSchemaControlsContainer/DeleteSchemaButton" to="." method="_on_delete_schema_button_pressed"]
 [connection signal="text_changed" from="MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit" to="." method="_on_edit_json_schema_code_edit_text_changed"]
+[connection signal="text_changed" from="MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit" to="." method="_on_schema_name_line_edit_text_changed"]


### PR DESCRIPTION
## Summary
- Sync JSON Schema title in code edit with the schema name line edit and vice versa
- Wire schema name line edit signal

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_rft_text_export.gd`
- `godot --headless --path src -s tests/test_model_output_sample.gd` *(fails: resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dfa3d12f883208c4dc110447d2b18