### PR TITLE
feat: add schema validator support

### DIFF
--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -3,6 +3,7 @@ extends ScrollContainer
 
 var default_schema_editor_url = "https://example.com/editor.php"
 var schema_loader_file_access_web = FileAccessWeb.new()
+var default_schema_validator_url = ""
 
 func to_var():
 	var me = {}
@@ -22,6 +23,7 @@ func to_var():
 	me["exportImagesHow"] = $VBoxContainer/ExportImagesHowContainer/ExportImagesHowOptionButton.selected
 	me["useUserNames"] = $VBoxContainer/UseUserNamesCheckbox.button_pressed
 	me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
+	me["schemaValidatorURL"] = $VBoxContainer/SchemaValidatorURLContainer/SchemaValidatorURLEdit.text
 	me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
 	me["imageUploadSetting"] = $VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton.selected
 	me["imageUploadServerURL"] = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
@@ -51,6 +53,7 @@ func from_var(me):
 			$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.select(i)
 	$VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.select(me.get("finetuneType", 0))
 	$VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
+	$VBoxContainer/SchemaValidatorURLContainer/SchemaValidatorURLEdit.text = me.get("schemaValidatorURL", default_schema_validator_url)
 	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
 	_on_schema_content_editor_text_changed()
 	$VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton.selected = me.get("imageUploadSetting", 0)

--- a/src/scenes/conversation_settings.tscn
+++ b/src/scenes/conversation_settings.tscn
@@ -504,6 +504,23 @@ layout_mode = 2
 text = "GENERIC_CHECK"
 icon = ExtResource("3_swtgl")
 
+[node name="SchemaValidatorURLContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="SchemaValidatorURLLabel" type="Label" parent="VBoxContainer/SchemaValidatorURLContainer"]
+layout_mode = 2
+text = "SETTINGS_SCHEMA_VALIDATOR_URL"
+
+[node name="SchemaValidatorURLHint" type="TextureRect" parent="VBoxContainer/SchemaValidatorURLContainer"]
+layout_mode = 2
+tooltip_text = "SETTINGS_SCHEMA_VALIDATOR_URL_HINT"
+texture = ExtResource("3_kcvkw")
+expand_mode = 2
+
+[node name="SchemaValidatorURLEdit" type="LineEdit" parent="VBoxContainer/SchemaValidatorURLContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
 [node name="SchemaContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -9,8 +9,9 @@ var SETTINGS = {
 	"useGlobalSystemMessage": false,
 	"globalSystemMessage": "",
 	"modelChoice": "gpt-4o",
-	"availableModels": []
-	}
+	"availableModels": [],
+	"schemaValidationURL": ""
+}
 
 var RUNTIME = {"filepath": ""}
 

--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -3,28 +3,121 @@ extends HBoxContainer
 const SchemaAlignOpenAI := preload("res://scenes/schemas/schema_align_openai.gd")
 
 var _updating_from_name := false
+@onready var _validator := $SchemaValidatorHTTPRequest
+var _pending_schema = null
+var _current_validation := ""
+const VALID_ICON_OK := "res://icons/code-json-check-positive.png"
+const VALID_ICON_BAD := "res://icons/code-json-check-negative.png"
 
+func _ready() -> void:
+	_validator.request_completed.connect(_on_schema_validator_request_completed)
+
+func _set_edit_pending() -> void:
+	var c := $MarginContainer/JSONSchemaControlsContainer/ValidatedSchemaContainer
+	c.get_node("Spinner").visible = true
+	c.get_node("SchemaValidateTextureRect").visible = false
+	$MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel.visible = false
+
+func _set_edit_result(ok: bool, msg := "") -> void:
+	var c := $MarginContainer/JSONSchemaControlsContainer/ValidatedSchemaContainer
+	c.get_node("Spinner").visible = false
+	c.get_node("SchemaValidateTextureRect").visible = true
+	if ok:
+		c.get_node("SchemaValidateTextureRect").texture = load(VALID_ICON_OK)
+		c.get_node("SchemaValidateLabel").text = "SCHEMAS_SCHEMA_VALIDATED"
+		$MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel.visible = false
+	else:
+		c.get_node("SchemaValidateTextureRect").texture = load(VALID_ICON_BAD)
+		c.get_node("SchemaValidateLabel").text = "SCHEMAS_SCHEMA_INVALID"
+		$MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel.visible = true
+		$MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel.text = msg
+
+func _set_oai_pending() -> void:
+	var c := $MarginContainer/JSONSchemaControlsContainer/OAIValidatedSchemaContainer2
+	c.get_node("Spinner").visible = true
+	c.get_node("SchemaValidateTextureRect").visible = false
+	$MarginContainer/JSONSchemaControlsContainer/OAISchemaErrorLabel.visible = false
+
+func _set_oai_result(ok: bool, msg := "") -> void:
+	var c := $MarginContainer/JSONSchemaControlsContainer/OAIValidatedSchemaContainer2
+	c.get_node("Spinner").visible = false
+	c.get_node("SchemaValidateTextureRect").visible = true
+	if ok:
+		c.get_node("SchemaValidateTextureRect").texture = load(VALID_ICON_OK)
+		c.get_node("SchemaValidateLabel").text = "SCHEMAS_SCHEMA_VALIDATED"
+		$MarginContainer/JSONSchemaControlsContainer/OAISchemaErrorLabel.visible = false
+	else:
+		c.get_node("SchemaValidateTextureRect").texture = load(VALID_ICON_BAD)
+		c.get_node("SchemaValidateLabel").text = "SCHEMAS_SCHEMA_INVALID"
+		$MarginContainer/JSONSchemaControlsContainer/OAISchemaErrorLabel.visible = true
+		$MarginContainer/JSONSchemaControlsContainer/OAISchemaErrorLabel.text = msg
 
 func _on_delete_schema_button_pressed() -> void:
 	queue_free()
-
 
 func _on_edit_json_schema_code_edit_text_changed() -> void:
 	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
 	var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
 	var name_edit := $MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit
+	oai_editor.text = ""
+	_set_oai_result(false)
 	var json := JSON.new()
 	var err := json.parse(editor.text)
 	if err != OK:
-		oai_editor.text = ""
+		_set_edit_result(false, "Invalid JSON")
 		return
-	var sanitized = SchemaAlignOpenAI.sanitize_envelope_or_schema(json.data)
-	oai_editor.text = JSON.stringify(sanitized, "\t")
+	var validator_url := get_node("/root/FineTune").SETTINGS.get("schemaValidationURL", "")
+	if validator_url == "":
+		_set_edit_result(false, "No validator URL")
+		return
+	_pending_schema = json.data
+	_set_edit_pending()
+	_current_validation = "edit"
+	var body = {"action": "validateSchema", "schema": json.data}
+	_validator.request(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, JSON.stringify(body))
 	if not _updating_from_name and json.data is Dictionary and json.data.has("title"):
 		var title = json.data["title"]
 		if title is String:
 			name_edit.text = title
 
+func _on_schema_validator_request_completed(result, response_code, headers, body):
+	var target := _current_validation
+	_current_validation = ""
+	var text := body.get_string_from_utf8()
+	var ok := false
+	var msg := ""
+	if result == HTTPRequest.RESULT_SUCCESS and response_code == 200:
+		var res = JSON.parse_string(text)
+		if res is Dictionary:
+			ok = res.get("ok", false)
+			if not ok and res.has("errors"):
+				msg = JSON.stringify(res["errors"])
+	else:
+		msg = "HTTP error"
+	if target == "edit":
+		if not ok:
+			_set_edit_result(false, msg)
+			return
+		_set_edit_result(true)
+		var sanitized = SchemaAlignOpenAI.sanitize_envelope_or_schema(_pending_schema)
+		var oai_text = JSON.stringify(sanitized, "	")
+		var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
+		oai_editor.text = oai_text
+		var json2 := JSON.new()
+		if json2.parse(oai_text) != OK:
+			_set_oai_result(false, "Invalid JSON")
+			return
+		_pending_schema = json2.data
+		var validator_url := get_node("/root/FineTune").SETTINGS.get("schemaValidationURL", "")
+		_set_oai_pending()
+		_current_validation = "oai"
+		var body2 = {"action": "validateSchema", "schema": json2.data}
+		_validator.request(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, JSON.stringify(body2))
+	elif target == "oai":
+		if not ok:
+			_set_oai_result(false, msg)
+			return
+		_set_oai_result(true)
 
 func _on_schema_name_line_edit_text_changed(new_text: String) -> void:
 	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
@@ -34,5 +127,5 @@ func _on_schema_name_line_edit_text_changed(new_text: String) -> void:
 		return
 	_updating_from_name = true
 	json.data["title"] = new_text
-	editor.text = JSON.stringify(json.data, "\t")
+	editor.text = JSON.stringify(json.data, "	")
 	_updating_from_name = false

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -479,6 +479,14 @@ msgid "SETTINGS_SCHEMA_EDITOR_URL_HINT"
 msgstr ""
 
 #: scenes/conversation_settings.tscn
+msgid "SETTINGS_SCHEMA_VALIDATOR_URL"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_SCHEMA_VALIDATOR_URL_HINT"
+msgstr ""
+
+#: scenes/conversation_settings.tscn
 msgid "GENERIC_CHECK"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- allow configuring schema validation script URL
- validate edited and OpenAI schemas via external PHP validator and update UI
- document new setting strings

## Testing
- `pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py`
- `godot --headless --path src -s res://tests/openai_import_test.gd` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_689e073aa42883208340917166b23644