### PR TITLE
Fix schema validator URL setting

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -10,7 +10,7 @@ var SETTINGS = {
 	"globalSystemMessage": "",
 	"modelChoice": "gpt-4o",
 	"availableModels": [],
-	"schemaValidationURL": ""
+"schemaValidatorURL": ""
 }
 
 var RUNTIME = {"filepath": ""}

--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -66,7 +66,7 @@ func _on_edit_json_schema_code_edit_text_changed() -> void:
 	if err != OK:
 		_set_edit_result(false, "Invalid JSON")
 		return
-	var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidationURL", "")
+var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidatorURL", "")
 	if validator_url == "":
 		_set_edit_result(false, "No validator URL")
 		return
@@ -108,7 +108,7 @@ func _on_schema_validator_request_completed(result, response_code, headers, body
 			_set_oai_result(false, "Invalid JSON")
 			return
 		_pending_schema = json2.data
-		var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidationURL", "")
+var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidatorURL", "")
 		_set_oai_pending()
 		_current_validation = "oai"
 		var body2 = {"action": "validateSchema", "schema": json2.data}


### PR DESCRIPTION
## Summary
- look up `schemaValidatorURL` instead of `schemaValidationURL` when validating schemas
- rename default setting key for validator URL

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -s tests/test_rft_text_export.gd`
- `godot --headless --path src -s tests/test_image_url_export.gd`
- `pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0ed015f48320a002cfe22a622b88