### PR TITLE
Fix schema validator request for JSON schema editing

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -74,7 +74,9 @@ func _on_edit_json_schema_code_edit_text_changed() -> void:
 	_set_edit_pending()
 	_current_validation = "edit"
 	var body = {"action": "validateSchema", "schema": json.data}
-	_validator.request(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, JSON.stringify(body))
+	var body_json = JSON.stringify(body)
+	var body_bytes: PackedByteArray = body_json.to_utf8_buffer()
+	_validator.request_raw(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, body_bytes)
 	if not _updating_from_name and json.data is Dictionary and json.data.has("title"):
 		var title = json.data["title"]
 		if title is String:
@@ -112,7 +114,9 @@ func _on_schema_validator_request_completed(result, response_code, headers, body
 		_set_oai_pending()
 		_current_validation = "oai"
 		var body2 = {"action": "validateSchema", "schema": json2.data}
-		_validator.request(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, JSON.stringify(body2))
+		var body_json2 = JSON.stringify(body2)
+		var body_bytes2: PackedByteArray = body_json2.to_utf8_buffer()
+		_validator.request_raw(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, body_bytes2)
 	elif target == "oai":
 		if not ok:
 			_set_oai_result(false, msg)


### PR DESCRIPTION
## Summary
- ensure schema validator uses raw byte POST body
- convert JSON schema validation payloads to UTF-8 bytes

## Testing
- `./check_tabs.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e11cbd70c832095bc69d690293844