### PR TITLE
Handle GET requests for schema validator

### DIFF
--- a/scripts/schema_validator.php
+++ b/scripts/schema_validator.php
@@ -858,6 +858,15 @@ if (php_sapi_name() !== 'cli') {
         exit;
     }
 
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        http_response_code(200);
+        echo json_encode([
+            'ok' => true,
+            'usage' => 'Send POST with JSON body: {"action":"validate"|"validateSchema","schema":{...},"data":{...}}'
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
         http_response_code(405);
         echo json_encode([

--- a/tests/test_schema_validator_api.py
+++ b/tests/test_schema_validator_api.py
@@ -68,5 +68,11 @@ class SchemaValidatorAPITest(unittest.TestCase):
         self.assertEqual(result["phase"], "instance")
         self.assertGreater(len(result["errors"]), 0)
 
+    def test_usage_on_get(self):
+        with urllib.request.urlopen("http://127.0.0.1:8001/") as resp:
+            self.assertEqual(resp.status, 200)
+            data = json.load(resp)
+        self.assertIn("usage", data)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Return usage information on GET requests to `schema_validator.php` instead of failing
- Test GET behavior of schema validator API

## Testing
- `php -l scripts/schema_validator.php`
- `pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689e1cd3764083208e87706af504c600