### PR TITLE
Fix schema validation request and add tests

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -73,7 +73,7 @@ func _on_edit_json_schema_code_edit_text_changed() -> void:
 	_pending_schema = json.data
 	_set_edit_pending()
 	_current_validation = "edit"
-	var body = {"action": "validateSchema", "schema": json.data}
+	var body = {"action": "validate_schema", "schema": json.data}
 	var body_json = JSON.stringify(body)
 	var body_bytes: PackedByteArray = body_json.to_utf8_buffer()
 	_validator.request_raw(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, body_bytes)
@@ -113,7 +113,7 @@ func _on_schema_validator_request_completed(result, response_code, headers, body
 		var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidatorURL", "")
 		_set_oai_pending()
 		_current_validation = "oai"
-		var body2 = {"action": "validateSchema", "schema": json2.data}
+		var body2 = {"action": "validate_schema", "schema": json2.data}
 		var body_json2 = JSON.stringify(body2)
 		var body_bytes2: PackedByteArray = body_json2.to_utf8_buffer()
 		_validator.request_raw(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, body_bytes2)

--- a/src/tests/test_schema_validator_request.gd
+++ b/src/tests/test_schema_validator_request.gd
@@ -1,0 +1,32 @@
+extends SceneTree
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var fine := Node.new()
+	fine.name = "FineTune"
+	fine.SETTINGS = {"schemaValidatorURL": "http://127.0.0.1:8001/"}
+	get_root().add_child(fine)
+
+	var scene = load("res://scenes/schemas/json_schema_container.tscn").instantiate()
+	get_root().add_child(scene)
+	await create_timer(0).timeout
+
+	var editor = scene.get_node("MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit")
+	var schema = {
+		"type": "object",
+		"properties": {"name": {"type": "string"}},
+		"required": ["name"],
+		"additionalProperties": false
+	}
+	editor.text = JSON.stringify(schema)
+
+	var validator = scene.get_node("SchemaValidatorHTTPRequest")
+	await validator.request_completed
+
+	var err_label = scene.get_node("MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel")
+	assert(err_label.text != "HTTP error")
+	print("Schema validator request succeeded")
+	quit(0)
+

--- a/tests/test_schema_validator_api.py
+++ b/tests/test_schema_validator_api.py
@@ -68,5 +68,19 @@ class SchemaValidatorAPITest(unittest.TestCase):
         self.assertEqual(result["phase"], "instance")
         self.assertGreater(len(result["errors"]), 0)
 
+    def test_validate_schema_only(self):
+        payload = {
+            "action": "validate_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        }
+        result = self.request(payload)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["phase"], "schema")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Use `validate_schema` action when requesting schema validation
- Add integration test for schema validator HTTP request
- Test PHP validator API for schema-only validation

## Testing
- `python -m pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py -q`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_689e1bae16e48320a6cc704072dfbe0c