### PR TITLE
Ensure schema validator works on PHP 7.3

### DIFF
--- a/scripts/schema_validator.php
+++ b/scripts/schema_validator.php
@@ -56,7 +56,7 @@ declare(strict_types=1);
 final class JsonSchemaValidator
 {
     /** @var array<string,bool> */
-    private array $supportedKeywords = [
+    private $supportedKeywords = [
         // core
         '$ref' => true, '$defs' => true, 'definitions' => true,
         // types & enums
@@ -87,9 +87,10 @@ final class JsonSchemaValidator
     ];
 
     /** @var array<string,mixed> */
-    private array $rootSchema = [];
+    private $rootSchema = [];
 
-    private int $maxDepth = 256;
+    /** @var int */
+    private $maxDepth = 256;
 
     /**
      * Validate JSON data against a schema.


### PR DESCRIPTION
## Summary
- Replace typed properties in schema_validator.php with docblocks for PHP 7.3 compatibility

## Testing
- `pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e22f7b10083208630a90e8f140171