### PR TITLE
Allow extra JSON schema annotations

### DIFF
--- a/tests/test_schema_validator_api.py
+++ b/tests/test_schema_validator_api.py
@@ -82,6 +82,90 @@ class SchemaValidatorAPITest(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["phase"], "schema")
 
+    def test_schema_with_extras(self):
+        schema = {
+            "title": "Person",
+            "type": "object",
+            "required": [
+                "name",
+                "age",
+                "date",
+                "favorite_color",
+                "gender",
+                "location",
+                "pets",
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "First and Last name",
+                    "minLength": 4,
+                    "default": "Jeremy Dorn",
+                },
+                "age": {
+                    "type": "integer",
+                    "default": 25,
+                    "minimum": 18,
+                    "maximum": 99,
+                },
+                "favorite_color": {
+                    "type": "string",
+                    "format": "color",
+                    "title": "favorite color",
+                    "default": "#ffa500",
+                },
+                "gender": {
+                    "type": "string",
+                    "enum": ["male", "female", "other"],
+                },
+                "date": {
+                    "type": "string",
+                    "format": "date",
+                    "options": {"flatpickr": {}},
+                },
+                "location": {
+                    "type": "object",
+                    "title": "Location",
+                    "properties": {
+                        "city": {"type": "string", "default": "San Francisco"},
+                        "state": {"type": "string", "default": "CA"},
+                        "citystate": {
+                            "type": "string",
+                            "description": "This is generated automatically from the previous two fields",
+                            "template": "{{city}}, {{state}}",
+                            "watch": {
+                                "city": "location.city",
+                                "state": "location.state",
+                            },
+                        },
+                    },
+                },
+                "pets": {
+                    "type": "array",
+                    "format": "table",
+                    "title": "Pets",
+                    "uniqueItems": True,
+                    "items": {
+                        "type": "object",
+                        "title": "Pet",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["cat", "dog", "bird", "reptile", "other"],
+                                "default": "dog",
+                            },
+                            "name": {"type": "string"},
+                        },
+                    },
+                    "default": [{"type": "dog", "name": "Walter"}],
+                },
+            },
+        }
+        payload = {"action": "validate_schema", "schema": schema}
+        result = self.request(payload)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["phase"], "schema")
+
     def test_usage_on_get(self):
         with urllib.request.urlopen("http://127.0.0.1:8001/") as resp:
             self.assertEqual(resp.status, 200)


### PR DESCRIPTION
## Summary
- permit `template`, `watch` and `options` keywords in schema validation
- relax `minLength`/`maxLength` checks to accept numeric values
- add regression test covering schema with extra annotations

## Testing
- `php scripts/schema_validator.php --validate-schema /tmp/schema.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e28c52b3c8320a7278923119bb27b