### PR TITLE
Derive schema name from title in OpenAI schema sanitizer

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -109,11 +109,11 @@ func _on_schema_validator_request_completed(result, response_code, headers, body
 		if json2.parse(oai_text) != OK:
 			_set_oai_result(false, "Invalid JSON")
 			return
-		_pending_schema = json2.data
+		_pending_schema = json2.data["schema"]
 		var validator_url = get_node("/root/FineTune").SETTINGS.get("schemaValidatorURL", "")
 		_set_oai_pending()
 		_current_validation = "oai"
-		var body2 = {"action": "validate_schema", "schema": json2.data}
+		var body2 = {"action": "validate_schema", "schema": _pending_schema}
 		var body_json2 = JSON.stringify(body2)
 		var body_bytes2: PackedByteArray = body_json2.to_utf8_buffer()
 		_validator.request_raw(validator_url, ["Content-Type: application/json"], HTTPClient.METHOD_POST, body_bytes2)

--- a/src/scenes/schemas/schema_align_openai.gd
+++ b/src/scenes/schemas/schema_align_openai.gd
@@ -149,8 +149,24 @@ static func sanitize_envelope_or_schema(data):
 	if typeof(data) == TYPE_DICTIONARY and not _is_schema_like(data):
 		var out = data.duplicate(true)
 		if out.has("schema"):
-			out["schema"] = sanitize_schema(out["schema"], true)
+			var schema = out["schema"]
+			if schema is Dictionary and schema.has("title") and schema["title"] is String:
+				out["name"] = schema["title"]
+			elif not out.has("name"):
+				out["name"] = ""
+			out["schema"] = sanitize_schema(schema, true)
 		if out.has("parameters"):
-			out["parameters"] = sanitize_schema(out["parameters"], true)
+			var params = out["parameters"]
+			if params is Dictionary and params.has("title") and params["title"] is String:
+				out["name"] = params["title"]
+			elif not out.has("name"):
+				out["name"] = ""
+			out["parameters"] = sanitize_schema(params, true)
+		if not out.has("name"):
+			out["name"] = ""
 		return out
-	return sanitize_schema(data, true)
+	var name := ""
+	if data is Dictionary and data.has("title") and data["title"] is String:
+		name = data["title"]
+	var sanitized = sanitize_schema(data, true)
+	return {"name": name, "schema": sanitized}

--- a/src/tests/test_schema_align_openai.gd
+++ b/src/tests/test_schema_align_openai.gd
@@ -12,6 +12,7 @@ func assert_eq(a, b, name := ""):
 func test_sanitize():
 	var align = load("res://scenes/schemas/schema_align_openai.gd")
 	var schema = {
+		"title": "Person",
 		"type": "object",
 		"properties": {
 			"name": {"type": "string", "minLength": 1}
@@ -21,10 +22,12 @@ func test_sanitize():
 		"required": []
 	}
 	var out = align.sanitize_envelope_or_schema(schema)
-	assert_eq(out["additionalProperties"], false, "additionalProperties")
-	assert_eq(out["required"][0], "name", "required filled")
-	assert_eq(out.has("allOf"), false, "allOf removed")
-	assert_eq(out["properties"]["name"].has("minLength"), false, "minLength removed")
+	assert_eq(out["name"], "Person", "name extracted")
+	var s = out["schema"]
+	assert_eq(s["additionalProperties"], false, "additionalProperties")
+	assert_eq(s["required"][0], "name", "required filled")
+	assert_eq(s.has("allOf"), false, "allOf removed")
+	assert_eq(s["properties"]["name"].has("minLength"), false, "minLength removed")
 
 func _init():
 	test_sanitize()

--- a/tests/test_schema_align_openai_api.py
+++ b/tests/test_schema_align_openai_api.py
@@ -40,12 +40,14 @@ class SchemaAlignOpenAITest(unittest.TestCase):
     def test_normalization(self):
         payload = {
             "schema": {
+                "title": "Example",
                 "type": "object",
                 "properties": {"a": {"type": "string"}},
                 "additionalProperties": True,
             }
         }
         result = self.request(payload)
+        self.assertEqual(result["name"], "Example")
         schema = result["schema"]
         self.assertEqual(schema["additionalProperties"], False)
         self.assertEqual(schema["required"], ["a"])


### PR DESCRIPTION
## Summary
- require a top-level `name` in sanitized schemas derived from the original `title`
- adjust Godot UI to validate the inner schema of the new envelope
- extend tests for PHP and GDScript to cover `name` handling

## Testing
- `./check_tabs.sh`
- `python -m pytest -q`
- `godot --headless --path src --script tests/test_schema_align_openai.gd`


------
https://chatgpt.com/codex/tasks/task_e_689e30f2c4288320ab7eda8c62f24566