### PR TITLE
Persist JSON schemas in project files

### DIFF
--- a/docs/ftproj_format.md
+++ b/docs/ftproj_format.md
@@ -6,7 +6,9 @@ The `.ftproj` file is a serialized representation of a fine‑tune project. The 
 {
   "functions": [],
   "conversations": {},
-  "settings": {}
+  "settings": {},
+  "graders": [],
+  "schemas": []
 }
 ```
 
@@ -16,6 +18,8 @@ Each section is described below along with the meaning of every field.
 - **`functions`**: Array of function definitions used when exporting or testing conversations.
 - **`conversations`**: Dictionary mapping a conversation ID to an array of message objects.
 - **`settings`**: Global configuration options for the project.
+- **`graders`**: Array of grader configurations used to evaluate conversations.
+- **`schemas`**: Array of JSON schema entries available in the project.
 
 ## Function entries
 
@@ -116,6 +120,16 @@ Global configuration stored in the `settings` object.
 | `countTokensWhen` | integer | Specifies when token counting is performed. |
 | `tokenCounts` | string | Cached token counts per conversation. |
 | `countTokensModel` | integer | Model used to estimate token counts. |
+
+## Schemas
+
+Each item in the `schemas` array represents one JSON schema definition.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Display name for the schema. |
+| `schema` | object | Original schema as entered by the user. |
+| `sanitizedSchema` | object | Sanitized version of the schema for safe usage. |
 
 ### Binary vs JSON
 

--- a/docs/ftproj_format_de.md
+++ b/docs/ftproj_format_de.md
@@ -6,7 +6,9 @@ Die Datei `.ftproj` speichert ein Fine‑Tune‑Projekt in serialisierter Form. 
 {
   "functions": [],
   "conversations": {},
-  "settings": {}
+  "settings": {},
+  "graders": [],
+  "schemas": []
 }
 ```
 
@@ -16,6 +18,8 @@ Nachfolgend werden alle Bereiche sowie die Bedeutung der einzelnen Felder erläu
 - **`functions`**: Liste von Funktionsdefinitionen, die beim Export oder Testen genutzt werden.
 - **`conversations`**: Dictionary, das eine Konversations‑ID auf eine Liste von Nachrichten abbildet.
 - **`settings`**: Globale Einstellungen des Projekts.
+- **`graders`**: Array von Grader-Konfigurationen zur Bewertung von Gesprächen.
+- **`schemas`**: Liste der verfügbaren JSON-Schemata.
 
 ## Funktionsobjekte
 
@@ -116,6 +120,16 @@ Globale Konfiguration, gespeichert im Objekt `settings`.
 | `countTokensWhen` | integer | Wann die Tokenzählung erfolgt. |
 | `tokenCounts` | string | Zwischengespeicherte Tokenzahlen pro Gespräch. |
 | `countTokensModel` | integer | Modell zur Schätzung der Tokenanzahl. |
+
+## Schemas
+
+Jedes Element im Array `schemas` beschreibt ein JSON-Schema.
+
+| Feld | Typ | Beschreibung |
+| --- | --- | --- |
+| `name` | string | Anzeigename des Schemas. |
+| `schema` | object | Ursprüngliches, vom Benutzer eingegebenes Schema. |
+| `sanitizedSchema` | object | Bereinigte Version des Schemas für die Verwendung. |
 
 ### Binär vs. JSON
 

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -4,6 +4,7 @@ var FINETUNEDATA = {}
 var FUNCTIONS = []
 var CONVERSATIONS = {}
 var GRADERS = []
+var SCHEMAS = []
 var SETTINGS = {
 	"apikey": "",
 	"useGlobalSystemMessage": false,
@@ -125,6 +126,7 @@ func _process(delta: float) -> void:
 		update_functions_internal()
 		update_settings_internal()
 		update_graders_internal()
+		update_schemas_internal()
 		if RUNTIME["filepath"] == "":
 			$VBoxContainer/SaveBtn/SaveFileDialog.visible = true
 		else:
@@ -154,6 +156,7 @@ func _on_save_btn_pressed() -> void:
 	update_functions_internal()
 	update_settings_internal()
 	update_graders_internal()
+	update_schemas_internal()
 	match OS.get_name():
 		"Windows", "Linux", "FreeBSD", "NetBSD", "OpenBSD", "BSD", "Android","macOS":
 			$VBoxContainer/SaveBtn/SaveFileDialog.visible = true
@@ -174,6 +177,10 @@ func update_settings_internal():
 	print(SETTINGS)
 func update_graders_internal():
 	GRADERS = $Conversation/Graders/GradersList.to_var()
+
+func update_schemas_internal():
+	SCHEMAS = $Conversation/Schemas/SchemasList.to_var()
+
 func get_available_function_names():
 	var tmpNames = []
 	for f in FUNCTIONS:
@@ -424,6 +431,7 @@ func _on_conversation_tab_changed(tab: int) -> void:
 	update_functions_internal()
 	update_settings_internal()
 	update_graders_internal()
+	update_schemas_internal()
 
 
 func create_new_conversation(msgs=[]):
@@ -470,6 +478,7 @@ func save_to_binary(filename):
 	FINETUNEDATA["conversations"] = CONVERSATIONS
 	FINETUNEDATA["settings"] = SETTINGS
 	FINETUNEDATA["graders"] = GRADERS
+	FINETUNEDATA["schemas"] = SCHEMAS
 	var file = FileAccess.open(filename, FileAccess.WRITE)
 	if file:
 		file.store_var(FINETUNEDATA)
@@ -487,6 +496,7 @@ func load_from_binary(filename):
 		CONVERSATIONS = FINETUNEDATA["conversations"]
 		SETTINGS = FINETUNEDATA["settings"]
 		GRADERS = FINETUNEDATA.get("graders", [])
+		SCHEMAS = FINETUNEDATA.get("schemas", [])
 		for i in CONVERSATIONS.keys():
 			CURRENT_EDITED_CONVO_IX = str(i)
 			$Conversation/Functions/FunctionsList.delete_all_functions_from_UI()
@@ -494,6 +504,7 @@ func load_from_binary(filename):
 			$Conversation/Functions/FunctionsList.from_var(FUNCTIONS)
 			$Conversation/Settings/ConversationSettings.from_var(SETTINGS)
 			$Conversation/Graders/GradersList.from_var(GRADERS)
+			$Conversation/Schemas/SchemasList.from_var(SCHEMAS)
 			$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 			refresh_conversations_list()
 			var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
@@ -514,11 +525,13 @@ func load_from_json_data(jsondata: String):
 	CONVERSATIONS = FINETUNEDATA["conversations"]
 	SETTINGS = FINETUNEDATA["settings"]
 	GRADERS = FINETUNEDATA.get("graders", [])
+	SCHEMAS = FINETUNEDATA.get("schemas", [])
 	for i in CONVERSATIONS.keys():
 		CURRENT_EDITED_CONVO_IX = str(i)
 	$Conversation/Settings/ConversationSettings.from_var(SETTINGS)
 	$Conversation/Functions/FunctionsList.from_var(FUNCTIONS)
 	$Conversation/Graders/GradersList.from_var(GRADERS)
+	$Conversation/Schemas/SchemasList.from_var(SCHEMAS)
 	$Conversation/Messages/MessagesList.from_var(CONVERSATIONS[CURRENT_EDITED_CONVO_IX])
 	refresh_conversations_list()
 	var selected_index = selectionStringToIndex($VBoxContainer/ConversationsList, CURRENT_EDITED_CONVO_IX)
@@ -534,6 +547,7 @@ func make_save_json_data():
 	FINETUNEDATA["conversations"] = CONVERSATIONS
 	FINETUNEDATA["settings"] = SETTINGS
 	FINETUNEDATA["graders"] = GRADERS
+	FINETUNEDATA["schemas"] = SCHEMAS
 	var jsonstr = JSON.stringify(FINETUNEDATA, "\t", false)
 	return jsonstr
 
@@ -570,6 +584,7 @@ func _on_save_file_dialog_file_selected(path: String) -> void:
 	update_functions_internal()
 	update_settings_internal()
 	update_graders_internal()
+	update_schemas_internal()
 	if path.ends_with(".json"):
 		save_to_json(path)
 	elif path.ends_with(".ftproj"):

--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -134,3 +134,42 @@ func _on_schema_name_line_edit_text_changed(new_text: String) -> void:
 	editor.text = JSON.stringify(json.data, "	")
 	_updating_from_name = false
 	_on_edit_json_schema_code_edit_text_changed()
+
+func to_var():
+	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
+	var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
+	var name := $MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit.text
+	var json := JSON.new()
+	var schema = null
+	if json.parse(editor.text) == OK:
+		schema = json.data
+	var json2 := JSON.new()
+	var sanitized_schema = null
+	if json2.parse(oai_editor.text) == OK and json2.data is Dictionary:
+		var dat = json2.data
+		sanitized_schema = dat.get("schema", dat)
+		if name == "" and dat.has("name") and dat["name"] is String:
+			name = dat["name"]
+	return {"schema": schema, "sanitizedSchema": sanitized_schema, "name": name}
+
+func from_var(data):
+	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
+	var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
+	var name_edit := $MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit
+	var schema = data.get("schema", null)
+	var sanitized_schema = data.get("sanitizedSchema", null)
+	var name = data.get("name", "")
+	if schema != null:
+		editor.text = JSON.stringify(schema, "\t")
+	else:
+		editor.text = ""
+	if sanitized_schema != null:
+		var envelope = {"name": name, "schema": sanitized_schema}
+		oai_editor.text = JSON.stringify(envelope, "\t")
+		_set_edit_result(true)
+		_set_oai_result(true)
+	else:
+		oai_editor.text = ""
+		_set_edit_result(false)
+		_set_oai_result(false)
+	name_edit.text = name


### PR DESCRIPTION
## Summary
- persist schemas alongside conversations, functions, settings and graders
- serialize each schema with original, sanitized form and name
- document new `schemas` project element

## Testing
- `./check_tabs.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e37cf456883208da961e92bdc1218