### PR TITLE
Populate schema dropdown dynamically

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -27,6 +27,7 @@ message=""
 function_use_parameter=""
 function_use_result=""
 UI_needs_function_list=""
+UI_needs_schema_list=""
 
 [gui]
 

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -180,6 +180,21 @@ func update_graders_internal():
 
 func update_schemas_internal():
 	SCHEMAS = $Conversation/Schemas/SchemasList.to_var()
+	update_available_schemas_in_UI_global()
+func get_available_schema_names():
+	var tmpNames = []
+	for s in SCHEMAS:
+		var name = s.get("name", "")
+		if name != "":
+			tmpNames.append(name)
+	return tmpNames
+
+func update_available_schemas_in_UI_global():
+	for node in get_tree().get_nodes_in_group("UI_needs_schema_list"):
+		node.clear()
+		for s in get_available_schema_names():
+			node.add_item(s)
+
 
 func get_available_function_names():
 	var tmpNames = []

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -279,7 +279,11 @@ func _ready() -> void:
 	for item in get_node("/root/FineTune").get_available_function_names():
 		$FunctionMessageContainer/function/FunctionNameChoiceButton.add_item(item)
 	$FunctionMessageContainer/function/FunctionNameChoiceButton.select(-1)
-	var finetunetype = get_node("/root/FineTune").SETTINGS.get("finetuneType", 0)
+	var ft_node = get_node("/root/FineTune")
+	if ft_node.has_method("update_available_schemas_in_UI_global"):
+		ft_node.update_available_schemas_in_UI_global()
+	$SchemaMessageContainer/OptionButton.select(-1)
+	var finetunetype = ft_node.SETTINGS.get("finetuneType", 0)
 	if finetunetype == 1:
 		# DPO: Only User and assistant messages are available, only text
 		$MessageSettingsContainer/MessageType.set_item_disabled(1, true)

--- a/src/scenes/message.tscn
+++ b/src/scenes/message.tscn
@@ -563,7 +563,7 @@ theme_override_font_sizes/font_size = 36
 text = "MESSAGES_JSON_SCHEMA_MESSAGE_TITLE"
 horizontal_alignment = 1
 
-[node name="OptionButton" type="OptionButton" parent="SchemaMessageContainer"]
+[node name="OptionButton" type="OptionButton" parent="SchemaMessageContainer" groups=["UI_needs_schema_list"]]
 custom_minimum_size = Vector2(0, 45)
 layout_mode = 2
 

--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -54,6 +54,7 @@ func _set_oai_result(ok: bool, msg := "") -> void:
 
 func _on_delete_schema_button_pressed() -> void:
 	queue_free()
+	get_node("/root/FineTune").call_deferred("update_schemas_internal")
 
 func _on_edit_json_schema_code_edit_text_changed() -> void:
 	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
@@ -134,6 +135,7 @@ func _on_schema_name_line_edit_text_changed(new_text: String) -> void:
 	editor.text = JSON.stringify(json.data, "	")
 	_updating_from_name = false
 	_on_edit_json_schema_code_edit_text_changed()
+	get_node("/root/FineTune").update_schemas_internal()
 
 func to_var():
 	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit

--- a/src/scenes/schemas/schemas.gd
+++ b/src/scenes/schemas/schemas.gd
@@ -6,6 +6,7 @@ func _on_add_schema_button_pressed() -> void:
 	var inst = SCHEMA_SCENE.instantiate()
 	$SchemasListVBox.add_child(inst)
 	$SchemasListVBox.move_child($SchemasListVBox/AddSchemaButton, -1)
+	get_node("/root/FineTune").update_schemas_internal()
 
 func to_var():
 	var all = []
@@ -27,3 +28,4 @@ func from_var(schemas_data):
 			if inst.has_method("from_var"):
 				inst.from_var(s)
 	$SchemasListVBox.move_child($SchemasListVBox/AddSchemaButton, -1)
+	get_node("/root/FineTune").update_schemas_internal()


### PR DESCRIPTION
## Summary
- Populate schema selection dropdown in message scene from available schemas
- Sync schema option lists whenever schema data changes
- Expose schema dropdown group in project settings

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --test` *(fails: binary lacks unit test support)*

------
https://chatgpt.com/codex/tasks/task_e_689e3eb1f68083208c7d4490fed6a3c0