### PR TITLE
Enable per-message schema selection

### DIFF
--- a/docs/ftproj_format.md
+++ b/docs/ftproj_format.md
@@ -70,6 +70,7 @@ The `conversations` dictionary stores all recorded dialogues. The key is the con
 | `functionResults` | string | Results returned by an executed function. |
 | `functionUsePreText` | string | Text prepended when executing a function. |
 | `userName` | string | Optional user display name. |
+| `jsonSchemaName` | string | Name of the selected JSON schema. |
 | `jsonSchemaValue` | string | Additional schema information. |
 | `metaData` | object | Information about the conversation itself. |
 | `audioData` | string | Base64 encoded audio data. |
@@ -114,7 +115,6 @@ Global configuration stored in the `settings` object.
 | `exportImagesHow` | integer | How image messages are exported. |
 | `useUserNames` | bool | Include user names in exported data. |
 | `schemaEditorURL` | string | URL to an external JSON schema editor. |
-| `jsonSchema` | string | Default JSON schema used for validation. |
 | `tokenCounterPath` | string | Path to an external token counting tool. |
 | `exportConvos` | integer | Determines which conversations are exported. |
 | `countTokensWhen` | integer | Specifies when token counting is performed. |

--- a/docs/ftproj_format_de.md
+++ b/docs/ftproj_format_de.md
@@ -70,6 +70,7 @@ Im Dictionary `conversations` werden alle aufgezeichneten Dialoge gespeichert. D
 | `functionResults` | string | Ergebnis einer ausgeführten Funktion. |
 | `functionUsePreText` | string | Text, der bei der Ausführung vorangestellt wird. |
 | `userName` | string | Optionaler Benutzername. |
+| `jsonSchemaName` | string | Name des ausgewählten JSON‑Schemas. |
 | `jsonSchemaValue` | string | Zusätzliche Schema‑Informationen. |
 | `metaData` | object | Informationen zur Konversation selbst. |
 | `audioData` | string | Base64‑kodierte Audiodaten. |
@@ -114,7 +115,6 @@ Globale Konfiguration, gespeichert im Objekt `settings`.
 | `exportImagesHow` | integer | Art und Weise des Bildexports. |
 | `useUserNames` | bool | Benutzernamen in exportierten Daten einbeziehen. |
 | `schemaEditorURL` | string | URL zu einem externen JSON-Schema-Editor. |
-| `jsonSchema` | string | Standard‑JSON-Schema zur Validierung. |
 | `tokenCounterPath` | string | Pfad zu einem externen Tool zur Tokenzählung. |
 | `exportConvos` | integer | Welche Gespräche exportiert werden. |
 | `countTokensWhen` | integer | Wann die Tokenzählung erfolgt. |

--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -2,7 +2,6 @@ extends ScrollContainer
 @onready var openai = get_tree().get_root().get_node("FineTune/OpenAi")
 
 var default_schema_editor_url = "https://example.com/editor.php"
-var schema_loader_file_access_web = FileAccessWeb.new()
 var default_schema_validator_url = ""
 
 func to_var():
@@ -24,7 +23,6 @@ func to_var():
 	me["useUserNames"] = $VBoxContainer/UseUserNamesCheckbox.button_pressed
 	me["schemaEditorURL"] = $VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text
 	me["schemaValidatorURL"] = $VBoxContainer/SchemaValidatorURLContainer/SchemaValidatorURLEdit.text
-	me["jsonSchema"] = $VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text
 	me["imageUploadSetting"] = $VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton.selected
 	me["imageUploadServerURL"] = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
 	me["imageUploadServerKey"] = $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text
@@ -54,8 +52,6 @@ func from_var(me):
 	$VBoxContainer/FineTuningTypeSettingContainer/FineTuningTypeSettingOptionButton.select(me.get("finetuneType", 0))
 	$VBoxContainer/SchemaEditorURLContainer/SchemaEditorURLEdit.text = me.get("schemaEditorURL", default_schema_editor_url)
 	$VBoxContainer/SchemaValidatorURLContainer/SchemaValidatorURLEdit.text = me.get("schemaValidatorURL", default_schema_validator_url)
-	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = me.get("jsonSchema", "")
-	_on_schema_content_editor_text_changed()
 	$VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton.selected = me.get("imageUploadSetting", 0)
 	$VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text = me.get("imageUploadServerURL", "")
 	$VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text = me.get("imageUploadServerKey", "")
@@ -83,8 +79,6 @@ func _ready() -> void:
 		$VBoxContainer/TokenCountModelChoiceContainer/TokenCountModelChoiceOptionButton.add_item(item)
 	# TODO: This should only be called if an OpenAI API key is set
 	openai.get_models()
-	schema_loader_file_access_web.loaded.connect(_on_schema_file_loaded)
-	#schema_loader_file_access_web.progress.connect(_on_file_access_web_progress)
 	print("OSNAME")
 	print(OS.get_name())
 	match OS.get_name():
@@ -93,12 +87,7 @@ func _ready() -> void:
 			$VBoxContainer/BatchCreatonContainer/BatchCreationButton.tooltip_text = tr("DISABLED_EXPLANATION_NOT_AVAILABLE_IN_WEB")
 			$VBoxContainer/TokenCountPathContainer/TokenCounterFilePickerBtn.disabled = true
 			$VBoxContainer/TokenCountPathContainer/TokenCounterFilePickerBtn.tooltip_text = tr("DISABLED_EXPLANATION_NOT_AVAILABLE_IN_WEB")
-			$VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.disabled = true
-func _on_schema_file_loaded(file_name: String, file_type: String, base64_data: String) -> void:
-	var txtdata = Marshalls.base64_to_utf8(base64_data)
-	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = txtdata
-	update_valid_json_for_schema_checker()
-
+				$VBoxContainer/TokenCountPathContainer/TokenCounterPathLineEdit.disabled = true
 func models_received(models: Array[String]):
 	# Make the selectable models the models that are given back here
 	$VBoxContainer/ModelChoiceContainer/ModelChoiceOptionButton.clear()
@@ -127,42 +116,6 @@ func load_available_fine_tuning_models_from_file():
 func _on_model_choice_refresh_button_pressed() -> void:
 	openai.get_models()
 
-
-func _on_schema_content_load_from_file_btn_pressed() -> void:
-	match OS.get_name():
-		"Web":
-			schema_loader_file_access_web.open(".json, .txt, .jsonschema, .schema")
-		_:
-			$VBoxContainer/SchemaContainer/LoadSchemaFileDialog.visible = true
-
-
-func _on_load_schema_file_dialog_file_selected(path: String) -> void:
-	var json_as_text = FileAccess.get_file_as_string(path)
-	$VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text = json_as_text
-	update_valid_json_for_schema_checker()
-	
-
-func validate_is_json(testtext) -> bool:
-	if testtext == "":
-		return false
-	var json = JSON.new()
-	var error = json.parse(testtext)
-	if error == OK:
-		return true
-	else:
-		return false
-		
-func update_valid_json_for_schema_checker() -> bool:
-	# The return value is not used in the function below, but it is when called externally by the message object
-	if validate_is_json($VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor.text):
-		$VBoxContainer/SchemaContainer/SchemaValidCheckImg.texture = load("res://icons/code-json-check-positive.png")
-		return true
-	else:
-		$VBoxContainer/SchemaContainer/SchemaValidCheckImg.texture = load("res://icons/code-json-check-negative.png")
-		return false
-
-func _on_schema_content_editor_text_changed() -> void:
-	update_valid_json_for_schema_checker()
 
 # Batch Creation
 func create_image_message_dict_from_path(path):

--- a/src/scenes/conversation_settings.tscn
+++ b/src/scenes/conversation_settings.tscn
@@ -521,40 +521,6 @@ expand_mode = 2
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="SchemaContainer" type="HBoxContainer" parent="VBoxContainer"]
-layout_mode = 2
-
-[node name="SchemaLabel" type="Label" parent="VBoxContainer/SchemaContainer"]
-layout_mode = 2
-text = "SETTINGS_SCHEMA"
-
-[node name="SchemaValidCheckImg" type="TextureRect" parent="VBoxContainer/SchemaContainer"]
-layout_mode = 2
-texture = ExtResource("6_uqjdu")
-stretch_mode = 3
-
-[node name="SchemaContentContainer" type="VBoxContainer" parent="VBoxContainer/SchemaContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="SchemaContentLoadFromFileBtn" type="Button" parent="VBoxContainer/SchemaContainer/SchemaContentContainer"]
-layout_mode = 2
-text = "SETTINGS_SCHEMA_LOAD_FILE
-"
-icon = ExtResource("6_3r4bh")
-
-[node name="SchemaContentEditor" type="CodeEdit" parent="VBoxContainer/SchemaContainer/SchemaContentContainer"]
-custom_minimum_size = Vector2(0, 400)
-layout_mode = 2
-size_flags_horizontal = 3
-wrap_mode = 1
-
-[node name="LoadSchemaFileDialog" type="FileDialog" parent="VBoxContainer/SchemaContainer"]
-title = "Open a File"
-ok_button_text = "Open"
-file_mode = 0
-access = 2
-use_native_dialog = true
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/GlobalSystemMessageCheckbox" to="." method="update_settings_global"]
 [connection signal="text_changed" from="VBoxContainer/HBoxContainer/GlobalSystemMessageContainer/GlobalSystemMessageTextEdit" to="." method="update_settings_global"]
@@ -572,6 +538,3 @@ use_native_dialog = true
 [connection signal="item_selected" from="VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton" to="." method="_on_image_uplaod_setting_option_button_item_selected"]
 [connection signal="text_changed" from="VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit" to="." method="_on_image_upload_server_url_edit_text_changed"]
 [connection signal="text_changed" from="VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit" to="." method="_on_image_upload_server_key_edit_text_changed"]
-[connection signal="pressed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentLoadFromFileBtn" to="." method="_on_schema_content_load_from_file_btn_pressed"]
-[connection signal="text_changed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor" to="." method="_on_schema_content_editor_text_changed"]
-[connection signal="file_selected" from="VBoxContainer/SchemaContainer/LoadSchemaFileDialog" to="." method="_on_load_schema_file_dialog_file_selected"]

--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -1148,3 +1148,14 @@ func conversation_from_openai_message_json(oaimsgjson):
 			i += 1
 
 	return NEWCONVO
+func get_schema_by_name(name: String):
+	for s in SCHEMAS:
+		if s.get("name", "") == name:
+			return s.get("schema", null)
+	return null
+
+func get_sanitized_schema_by_name(name: String):
+	for s in SCHEMAS:
+		if s.get("name", "") == name:
+			return s.get("sanitizedSchema", null)
+	return null

--- a/src/scenes/message.tscn
+++ b/src/scenes/message.tscn
@@ -647,6 +647,7 @@ layout_mode = 2
 [connection signal="pressed" from="MetaMessageContainer/ShowMetaMessageToggleButton" to="." method="_on_show_meta_message_toggle_button_pressed"]
 [connection signal="pressed" from="MetaMessageContainer/MetaMessageToggleCostEstimationButton" to="." method="_on_meta_message_toggle_cost_estimation_button_pressed"]
 [connection signal="pressed" from="MetaMessageContainer/Button3" to="." method="_do_token_calculation_update"]
+[connection signal="item_selected" from="SchemaMessageContainer/OptionButton" to="." method="_on_something_int_changed"]
 [connection signal="pressed" from="SchemaMessageContainer/SchemaEditButtonsContainer/SchemaEditButton" to="." method="_on_schema_edit_button_pressed"]
 [connection signal="pressed" from="SchemaMessageContainer/SchemaMessagePolling/SchemaMessagePollingReopenBrowserBtn" to="." method="_on_schema_message_polling_reopen_browser_btn_pressed"]
 [connection signal="request_completed" from="SchemaMessageContainer/InitEditingRequestToken" to="." method="_on_init_editing_request_token_request_completed"]

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -544,6 +544,10 @@ msgid "DISABLED_EXPLANATION_NEEDS_VALID_JSON_IN_SETTINGS"
 msgstr "A valid JSON schema in the settings is needed to use that"
 
 #: scenes/message.gd
+msgid "DISABLED_EXPLANATION_NEEDS_AT_LEAST_ONE_SCHEMA"
+msgstr "At least one schema must be defined to use that"
+
+#: scenes/message.gd
 msgid "DISABLED_EXPLANATION_DPO_ONLY_SUPPORTS_TEXT"
 msgstr "Direct Prefernce Optimization (DPO) only supports text"
 

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -562,6 +562,10 @@ msgid "DISABLED_EXPLANATION_NEEDS_VALID_JSON_IN_SETTINGS"
 msgstr "Ein valides JSON Schema muss in den Einstellungen hinterlegt werden um das benutzen zu können"
 
 #: scenes/message.gd
+msgid "DISABLED_EXPLANATION_NEEDS_AT_LEAST_ONE_SCHEMA"
+msgstr "Mindestens ein Schema muss definiert sein um das nutzen zu können"
+
+#: scenes/message.gd
 msgid "DISABLED_EXPLANATION_DPO_ONLY_SUPPORTS_TEXT"
 msgstr "Direct Preference Optimization (DPO) unterstüzt nur Text"
 

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -597,6 +597,10 @@ msgid "DISABLED_EXPLANATION_NEEDS_VALID_JSON_IN_SETTINGS"
 msgstr ""
 
 #: scenes/message.gd
+msgid "DISABLED_EXPLANATION_NEEDS_AT_LEAST_ONE_SCHEMA"
+msgstr ""
+
+#: scenes/message.gd
 msgid "DISABLED_EXPLANATION_DPO_ONLY_SUPPORTS_TEXT"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- allow choosing JSON schema per message via UI option button
- drop single-schema settings and document per-message schema names
- add helper lookups for schema data

## Testing
- `./check_tabs.sh`
- `pytest`
- `godot --headless --path src --run-tests` *(fails: Missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e4548a5748320b9d9d4019837bb95