### PR TITLE
feat: translate schema tabs

### DIFF
--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -11,6 +11,9 @@ const VALID_ICON_BAD := "res://icons/code-json-check-negative.png"
 
 func _ready() -> void:
 	_validator.request_completed.connect(_on_schema_validator_request_completed)
+	var tab_bar = $MarginContainer2/SchemasTabContainer.get_tab_bar()
+	tab_bar.set_tab_title(0, tr("Edit JSON Schema"))
+	tab_bar.set_tab_title(1, tr("OpenAI JSON Schema"))
 
 func _set_edit_pending() -> void:
 	var c := $MarginContainer/JSONSchemaControlsContainer/ValidatedSchemaContainer

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -1404,3 +1404,11 @@ msgstr "Grader verification error!"
 msgid "GRADER_VERIFIED"
 msgstr "Verified!"
 
+#: scenes/schemas/json_schema_container.gd
+msgid "Edit JSON Schema"
+msgstr ""
+
+#: scenes/schemas/json_schema_container.gd
+msgid "OpenAI JSON Schema"
+msgstr ""
+

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -1422,3 +1422,11 @@ msgstr "Verifizierungsfehler!"
 msgid "GRADER_VERIFIED"
 msgstr "Verifiziert!"
 
+#: scenes/schemas/json_schema_container.gd
+msgid "Edit JSON Schema"
+msgstr ""
+
+#: scenes/schemas/json_schema_container.gd
+msgid "OpenAI JSON Schema"
+msgstr ""
+

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -1234,3 +1234,11 @@ msgstr ""
 #: scenes/graders/grader_container.gd
 msgid "GRADER_VERIFIED"
 msgstr ""
+
+#: scenes/schemas/json_schema_container.gd
+msgid "Edit JSON Schema"
+msgstr ""
+
+#: scenes/schemas/json_schema_container.gd
+msgid "OpenAI JSON Schema"
+msgstr ""


### PR DESCRIPTION
## Summary
- set schema editor tab titles through translations
- add translation entries for new tab labels

## Testing
- `./check_tabs.sh`
- `godot --headless --path src -q` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_689e5290e7e083208251a7eefee8fd6d