### PR TITLE
require API key for grader verification

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -59,6 +59,12 @@ func _exit_tree() -> void:
 
 func verify_grader() -> bool:
 	print("Verifying grader!")
+	var api_key = get_node("/root/FineTune").SETTINGS.get("apikey", "")
+	if api_key == "":
+		_status_label.text = tr("DISABLED_EXPLANATION_NEEDS_OPENAI_API_KEY")
+		_spinner.visible = false
+		_use_button.button_pressed = false
+		return false
 	_set_grader_controls_disabled(true)
 
 	var grader_gui = null


### PR DESCRIPTION
## Summary
- require an API key in settings before grader verification runs

## Testing
- `./check_tabs.sh`
- `pytest -q`
- `godot --headless --path src -s tests/test_grader.gd`
- `godot --headless --path src -s tests/test_grader_item_wrap.gd` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_689e53c827dc8320987f6e4d01c7a938