### PR TITLE
Fix integer validation for float values

### DIFF
--- a/scripts/schema_validator.php
+++ b/scripts/schema_validator.php
@@ -760,25 +760,45 @@ final class JsonSchemaValidator
     private function matchesType($data, string $type): bool
     {
         switch ($type) {
-            case 'null': return $data === null;
-            case 'boolean': return is_bool($data);
-            case 'integer': return is_int($data);
-            case 'number': return is_int($data) || is_float($data);
-            case 'string': return is_string($data);
-            case 'array': return is_array($data) && $this->isList($data);
-            case 'object': return is_array($data) && $this->isAssoc($data);
-            default: return false;
+            case 'null':
+                return $data === null;
+            case 'boolean':
+                return is_bool($data);
+            case 'integer':
+                return is_int($data) || (is_float($data) && floor($data) == $data);
+            case 'number':
+                return is_int($data) || is_float($data);
+            case 'string':
+                return is_string($data);
+            case 'array':
+                return is_array($data) && $this->isList($data);
+            case 'object':
+                return is_array($data) && $this->isAssoc($data);
+            default:
+                return false;
         }
     }
 
     private function typeOf($data): string
     {
-        if ($data === null) return 'null';
-        if (is_bool($data)) return 'boolean';
-        if (is_int($data)) return 'integer';
-        if (is_float($data)) return 'number';
-        if (is_string($data)) return 'string';
-        if (is_array($data)) return $this->isList($data) ? 'array' : 'object';
+        if ($data === null) {
+            return 'null';
+        }
+        if (is_bool($data)) {
+            return 'boolean';
+        }
+        if (is_int($data)) {
+            return 'integer';
+        }
+        if (is_float($data)) {
+            return floor($data) == $data ? 'integer' : 'number';
+        }
+        if (is_string($data)) {
+            return 'string';
+        }
+        if (is_array($data)) {
+            return $this->isList($data) ? 'array' : 'object';
+        }
         return 'unknown';
     }
 

--- a/tests/test_schema_validator_api.py
+++ b/tests/test_schema_validator_api.py
@@ -82,6 +82,21 @@ class SchemaValidatorAPITest(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["phase"], "schema")
 
+    def test_integer_accepts_float_equivalent(self):
+        payload = {
+            "action": "validate",
+            "schema": {
+                "type": "object",
+                "properties": {"age": {"type": "integer"}},
+                "required": ["age"],
+                "additionalProperties": False,
+            },
+            "data": {"age": 67.0},
+        }
+        result = self.request(payload)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["phase"], "instance")
+
     def test_schema_with_extras(self):
         schema = {
             "title": "Person",


### PR DESCRIPTION
## Summary
- allow floats representing whole numbers to satisfy the `integer` type in schema validation
- test schema validator API for accepting float-encoded integers

## Testing
- `python -m pytest tests/test_schema_validator_api.py -q`
- `godot -e --headless --path src --quit-after 2`
- `godot --headless --path src --script tests/test_schema_validator_request.gd` *(fails: Invalid assignment of property or key 'SETTINGS')*

------
https://chatgpt.com/codex/tasks/task_e_689f06de506c8320a7317dba7bfa5690