### PR TITLE
feat: debounce schema and message validation

### DIFF
--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -10,6 +10,7 @@ var last_base64_to_upload = ""
 
 const VALID_ICON_OK := "res://icons/code-json-check-positive.png"
 const VALID_ICON_BAD := "res://icons/code-json-check-negative.png"
+var _schema_validate_timer: Timer
 
 func selectionStringToIndex(node, string):
 	# takes a node (OptionButton) and a String that is one of the options and returns its index
@@ -311,6 +312,11 @@ func _ready() -> void:
 	$SchemaMessageContainer/SchemaEdit.text_changed.connect(_on_schema_edit_text_changed)
 	$SchemaMessageContainer/HBoxContainer/SchemaValidationHTTPRequest.request_completed.connect(_on_schema_validation_http_request_completed)
 	$SchemaMessageContainer/HBoxContainer/OptionButton.item_selected.connect(_on_schema_option_selected)
+	_schema_validate_timer = Timer.new()
+	_schema_validate_timer.one_shot = true
+	_schema_validate_timer.wait_time = 2.0
+	add_child(_schema_validate_timer)
+	_schema_validate_timer.connect("timeout", Callable(self, "_on_schema_validate_timeout"))
 	_set_schema_validation_idle()
 
 func _on_progress(current_bytes: int, total_bytes: int) -> void:
@@ -625,9 +631,15 @@ func _on_schema_validation_http_request_completed(result, response_code, headers
 
 func _on_schema_edit_text_changed() -> void:
 	update_messages_global()
-	_validate_schema_message()
+	_schedule_schema_validate()
 
 func _on_schema_option_selected(index: int) -> void:
+	_schedule_schema_validate()
+
+func _schedule_schema_validate() -> void:
+	_schema_validate_timer.start()
+
+func _on_schema_validate_timeout() -> void:
 	_validate_schema_message()
 ## Funktionen, die den nachrichtenverlauf speichern wenn etwas passiert
 

--- a/src/scenes/schemas/json_schema_container.gd
+++ b/src/scenes/schemas/json_schema_container.gd
@@ -8,12 +8,18 @@ var _pending_schema = null
 var _current_validation := ""
 const VALID_ICON_OK := "res://icons/code-json-check-positive.png"
 const VALID_ICON_BAD := "res://icons/code-json-check-negative.png"
+var _validate_timer: Timer
 
 func _ready() -> void:
 	_validator.request_completed.connect(_on_schema_validator_request_completed)
 	var tab_bar = $MarginContainer2/SchemasTabContainer.get_tab_bar()
 	tab_bar.set_tab_title(0, tr("Edit JSON Schema"))
 	tab_bar.set_tab_title(1, tr("OpenAI JSON Schema"))
+	_validate_timer = Timer.new()
+	_validate_timer.one_shot = true
+	_validate_timer.wait_time = 2.0
+	add_child(_validate_timer)
+	_validate_timer.connect("timeout", Callable(self, "_on_validate_timeout"))
 
 func _set_edit_pending() -> void:
 	var c := $MarginContainer/JSONSchemaControlsContainer/ValidatedSchemaContainer
@@ -60,6 +66,9 @@ func _on_delete_schema_button_pressed() -> void:
 	get_node("/root/FineTune").call_deferred("update_schemas_internal")
 
 func _on_edit_json_schema_code_edit_text_changed() -> void:
+	_validate_timer.start()
+
+func _on_validate_timeout() -> void:
 	var editor := $MarginContainer2/SchemasTabContainer/EditSchemaTabBar/VBoxContainer/EditJSONSchemaCodeEdit
 	var oai_editor := $MarginContainer2/SchemasTabContainer/OAISchemaTabBar/VBoxContainer/OAIJSONSchemaCodeEdit
 	var name_edit := $MarginContainer/JSONSchemaControlsContainer/SchemaNameContainer/LineEdit


### PR DESCRIPTION
## Summary
- debounce schema validation requests
- debounce message schema validation

## Testing
- `godot -e --headless --path src --quit-after 2`
- `godot --headless --path src --script tests/test_schema_validator_request.gd` *(fails: Invalid assignment of property or key 'SETTINGS')*
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: Assertion failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f0aef9bb483209283a8982815300f