### PR TITLE
Revalidate message schema after programmatic changes

### DIFF
--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -143,6 +143,7 @@ func from_var(data):
 	$SchemaMessageContainer/SchemaEdit.text = data.get("jsonSchemaValue", "{}")
 	var saved_name = data.get("jsonSchemaName", "")
 	$SchemaMessageContainer/HBoxContainer/OptionButton.select(selectionStringToIndex($SchemaMessageContainer/HBoxContainer/OptionButton, saved_name))
+	_validate_schema_message()
 	# Audio Message
 	$AudioMessageContainer/Base64AudioEdit.text = data.get("audioData", "")
 	$AudioMessageContainer/TranscriptionContainer/RichTextLabel.text = data.get("audioTranscript", "")
@@ -849,6 +850,8 @@ func _on_poll_for_completion_request_completed(result: int, response_code: int, 
 			$SchemaMessageContainer/SchemaMessagePolling.visible = false
 			$SchemaMessageContainer/SchemaEdit.visible = true
 			$SchemaMessageContainer/SchemaEditButtonsContainer.visible = true
+			update_messages_global()
+			_validate_schema_message()
 
 
 func _on_schema_message_polling_reopen_browser_btn_pressed() -> void:


### PR DESCRIPTION
## Summary
- Trigger schema validation when message JSON is updated programmatically
- Revalidate and save messages after returning from external schema editor

## Testing
- `./check_tabs.sh`
- `pytest`
- `godot -e --headless --path src --quit-after 2`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: Assertion failed at _run)*
- `godot --headless --path src --script tests/test_import_openai.gd` *(errors: File Access Web worked only for HTML5 platform export)*
- `godot --headless --path src --script tests/test_grader_item_wrap.gd` *(errors: Signal already connected)*

------
https://chatgpt.com/codex/tasks/task_e_689f0d48e3108320ab0ebc9e30c23632