### PR TITLE
feat: allow testing image upload server credentials

### DIFF
--- a/scripts/image-upload.php
+++ b/scripts/image-upload.php
@@ -56,6 +56,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
 }
 
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['test'])) {
+       $key = $_GET['key'] ?? '';
+       if ($key !== $SECRET_KEY) {
+               http_response_code(403);
+               echo 'invalid key';
+       } else {
+               echo 'ok';
+       }
+       exit;
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['image'])) {
 	$file = basename($_GET['image']);
 	$path = $UPLOAD_DIR . '/' . $file;

--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -218,3 +218,21 @@ func _on_image_upload_server_url_edit_text_changed(new_text: String) -> void:
 
 func _on_image_uplaod_setting_option_button_item_selected(index: int) -> void:
 	update_settings_global()
+
+func _on_image_upload_server_test_button_pressed() -> void:
+	var upload_url = $VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit.text
+	var upload_key = $VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit.text
+	if upload_url == "" or upload_key == "":
+		$VBoxContainer/ImageUploadServerTestContainer/ImageUploadServerTestResultImg.texture = load("res://icons/code-json-check-negative.png")
+		return
+	var test_url = upload_url + "?test=1&key=" + upload_key
+	var err = $ImageUploadServerTestRequest.request(test_url)
+	if err != OK:
+		$VBoxContainer/ImageUploadServerTestContainer/ImageUploadServerTestResultImg.texture = load("res://icons/code-json-check-negative.png")
+
+func _on_image_upload_server_test_request_completed(result, response_code, headers, body):
+	var txt = body.get_string_from_utf8().strip_edges()
+	if response_code == 200 and txt == "ok":
+		$VBoxContainer/ImageUploadServerTestContainer/ImageUploadServerTestResultImg.texture = load("res://icons/code-json-check-positive.png")
+	else:
+		$VBoxContainer/ImageUploadServerTestContainer/ImageUploadServerTestResultImg.texture = load("res://icons/code-json-check-negative.png")

--- a/src/scenes/conversation_settings.tscn
+++ b/src/scenes/conversation_settings.tscn
@@ -29,6 +29,8 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_efb5c")
 
+[node name="ImageUploadServerTestRequest" type="HTTPRequest" parent="."]
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -478,6 +480,18 @@ layout_mode = 2
 size_flags_horizontal = 3
 secret = true
 
+[node name="ImageUploadServerTestContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ImageUploadServerTestButton" type="Button" parent="VBoxContainer/ImageUploadServerTestContainer"]
+layout_mode = 2
+text = "SETTINGS_IMAGE_UPLOAD_TEST_BUTTON"
+
+[node name="ImageUploadServerTestResultImg" type="TextureRect" parent="VBoxContainer/ImageUploadServerTestContainer"]
+layout_mode = 2
+texture = ExtResource("6_uqjdu")
+stretch_mode = 3
+
 [node name="SchemaSettingsSeparator" type="HSeparator" parent="VBoxContainer"]
 layout_mode = 2
 
@@ -555,6 +569,8 @@ use_native_dialog = true
 [connection signal="item_selected" from="VBoxContainer/ImageUplaodSettingContainer/ImageUplaodSettingOptionButton" to="." method="_on_image_uplaod_setting_option_button_item_selected"]
 [connection signal="text_changed" from="VBoxContainer/ImageUploadServerURLContainer/ImageUploadServerURLEdit" to="." method="_on_image_upload_server_url_edit_text_changed"]
 [connection signal="text_changed" from="VBoxContainer/ImageUploadServerKeyContainer/ImageUploadServerKeyEdit" to="." method="_on_image_upload_server_key_edit_text_changed"]
+[connection signal="pressed" from="VBoxContainer/ImageUploadServerTestContainer/ImageUploadServerTestButton" to="." method="_on_image_upload_server_test_button_pressed"]
+[connection signal="request_completed" from="ImageUploadServerTestRequest" to="." method="_on_image_upload_server_test_request_completed"]
 [connection signal="pressed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentLoadFromFileBtn" to="." method="_on_schema_content_load_from_file_btn_pressed"]
 [connection signal="text_changed" from="VBoxContainer/SchemaContainer/SchemaContentContainer/SchemaContentEditor" to="." method="_on_schema_content_editor_text_changed"]
 [connection signal="file_selected" from="VBoxContainer/SchemaContainer/LoadSchemaFileDialog" to="." method="_on_load_schema_file_dialog_file_selected"]

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -986,6 +986,10 @@ msgstr "Secret key"
 msgid "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
 msgstr "The secret key you've set in the upload-image.php file"
 
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_TEST_BUTTON"
+msgstr "Test upload server"
+
 #: scenes/conversation.tscn
 msgid "Graders"
 msgstr ""

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -1004,6 +1004,10 @@ msgstr "Geheimer Schlüssel"
 msgid "SETTINGS_IMAGE_UPLOAD_KEY_HINT"
 msgstr "Der geheime Schlüssel, der in der upload-image.php festgelegt wurde"
 
+#: scenes/conversation_settings.tscn
+msgid "SETTINGS_IMAGE_UPLOAD_TEST_BUTTON"
+msgstr "Upload-Server testen"
+
 #: scenes/conversation.tscn
 msgid "Graders"
 msgstr ""


### PR DESCRIPTION
## Summary
- allow image-upload.php to validate credentials via a `test` query
- add UI button in conversation settings to verify upload server URL and key
- localize new image upload test button

## Testing
- `./check_tabs.sh`
- `godot -e --headless --path src --quit-after 2`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: File not found)*
- `godot --headless --path src --script tests/test_application_start.gd`
- `python scripts/test-image-upload.py http://127.0.0.1:8000/image-upload.php --key gaertner`
- `curl "http://127.0.0.1:8000/image-upload.php?test=1&key=gaertner"`
- `curl -i "http://127.0.0.1:8000/image-upload.php?test=1&key=wrong"`


------
https://chatgpt.com/codex/tasks/task_e_689f1a779f18832085d4b26ef5f140c5