### PR TITLE
feat: add in-app schema validation

### DIFF
--- a/src/json_schema_validator.gd
+++ b/src/json_schema_validator.gd
@@ -1,0 +1,75 @@
+extends RefCounted
+
+class_name JsonSchemaValidator
+
+static func validate_schema(schema: Dictionary) -> Dictionary:
+	var errors: Array = []
+	_validate_schema_node(schema, "", errors)
+	return {"ok": errors.is_empty(), "phase": "schema", "errors": errors}
+
+static func validate(data, schema: Dictionary) -> Dictionary:
+	var errors: Array = []
+	_validate(data, schema, "", errors)
+	return {"ok": errors.is_empty(), "phase": "instance", "errors": errors}
+
+static func _validate_schema_node(schema, path: String, errors: Array) -> void:
+	if typeof(schema) != TYPE_DICTIONARY:
+		errors.append({"path": path, "message": "schema must be object"})
+		return
+	var t = schema.get("type", null)
+	if t != null and typeof(t) != TYPE_STRING:
+		errors.append({"path": path + "/type", "message": "type must be string"})
+	var props = schema.get("properties", null)
+	if props != null and typeof(props) == TYPE_DICTIONARY:
+		for key in props.keys():
+			_validate_schema_node(props[key], path + "/properties/" + str(key), errors)
+	var items = schema.get("items", null)
+	if items != null:
+		_validate_schema_node(items, path + "/items", errors)
+
+static func _validate(data, schema, path: String, errors: Array) -> void:
+	var t = schema.get("type", null)
+	match t:
+		"object":
+			if typeof(data) != TYPE_DICTIONARY:
+				errors.append({"path": path, "message": "expected object"})
+				return
+			var props: Dictionary = schema.get("properties", {})
+			for key in data.keys():
+				if props.has(key):
+					_validate(data[key], props[key], path + "/" + str(key), errors)
+				elif schema.get("additionalProperties", true) == false:
+					errors.append({"path": path + "/" + str(key), "message": "additional property"})
+			var req = schema.get("required", [])
+			for r in req:
+				if not data.has(r):
+					errors.append({"path": path + "/" + str(r), "message": "missing property"})
+		"string":
+			if typeof(data) != TYPE_STRING:
+				errors.append({"path": path, "message": "expected string"})
+		"integer":
+			if typeof(data) == TYPE_INT:
+				pass
+			elif typeof(data) == TYPE_FLOAT and int(data) == data:
+				pass
+			else:
+				errors.append({"path": path, "message": "expected integer"})
+		"number":
+			if typeof(data) != TYPE_INT and typeof(data) != TYPE_FLOAT:
+				errors.append({"path": path, "message": "expected number"})
+		"array":
+			if typeof(data) != TYPE_ARRAY:
+				errors.append({"path": path, "message": "expected array"})
+				return
+			var items_schema = schema.get("items", null)
+			if items_schema != null:
+				for i in data.size():
+					_validate(data[i], items_schema, path + "/" + str(i), errors)
+		"boolean":
+			if typeof(data) != TYPE_BOOL:
+				errors.append({"path": path, "message": "expected boolean"})
+		"null":
+			if data != null:
+				errors.append({"path": path, "message": "expected null"})
+		_:
+			pass

--- a/src/tests/test_schema_validator_request.gd
+++ b/src/tests/test_schema_validator_request.gd
@@ -6,7 +6,6 @@ func _init():
 func _run():
 	var fine := Node.new()
 	fine.name = "FineTune"
-	fine.SETTINGS = {"schemaValidatorURL": "http://127.0.0.1:8001/"}
 	get_root().add_child(fine)
 
 	var scene = load("res://scenes/schemas/json_schema_container.tscn").instantiate()
@@ -22,11 +21,8 @@ func _run():
 	}
 	editor.text = JSON.stringify(schema)
 
-	var validator = scene.get_node("SchemaValidatorHTTPRequest")
-	await validator.request_completed
-
+	await create_timer(3).timeout
 	var err_label = scene.get_node("MarginContainer/JSONSchemaControlsContainer/SchemaErrorLabel")
-	assert(err_label.text != "HTTP error")
-	print("Schema validator request succeeded")
+	assert(err_label.visible == false)
+	print("Schema validator local validation succeeded")
 	quit(0)
-


### PR DESCRIPTION
## Summary
- port PHP schema validator to GDScript for in-app use
- validate schemas locally in JSON schema editor
- validate message payloads against schemas without HTTP requests
- update validator test to cover local execution

## Testing
- `./check_tabs.sh`
- `pytest tests/test_schema_validator_api.py tests/test_schema_align_openai_api.py`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: missing imported resources)*
- `godot --headless --path src --script tests/test_schema_validator_request.gd` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_689f1a0c29448320b43d3d5cc5fea9e4