### PR TITLE
Fix missing JSON validation in conversation settings

### DIFF
--- a/src/scenes/conversation_settings.gd
+++ b/src/scenes/conversation_settings.gd
@@ -113,6 +113,15 @@ func load_available_fine_tuning_models_from_file():
 	var costs = JSON.parse_string(cost_json)
 	return costs["available_models"]
 
+func validate_is_json(testtext) -> bool:
+	if testtext == "":
+		return false
+	var json = JSON.new()
+	var err = json.parse(testtext)
+	if err == OK:
+		return true
+	return false
+
 
 func _on_model_choice_refresh_button_pressed() -> void:
 	openai.get_models()


### PR DESCRIPTION
## Summary
- expose `validate_is_json` on ConversationSettings to check clipboard/schema content

## Testing
- `godot -e --headless --path src --quit-after 2` *(fails: Identifier "_on_schema_validation_http_request_completed" not declared)*
- `bash check_tabs.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f2aa8b4608320bb2a01d474f18286