### PR TITLE
Show export progress during file generation

### DIFF
--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -316,6 +316,10 @@ msgstr "The model that should be used for completions. Note that although all mo
 msgid "FINETUNE_EXPORT"
 msgstr "Export Fine-Tune"
 
+#: scenes/fine_tune.gd
+msgid "FINETUNE_EXPORTING"
+msgstr "Exporting"
+
 #: scenes/fine_tune.tscn
 msgid "GENERIC_SAVE"
 msgstr "Save"

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -328,6 +328,10 @@ msgstr "Das Modell das für Vervollständigungen genutzt werden soll.\n"
 msgid "FINETUNE_EXPORT"
 msgstr "Exportiere Fine-Tune"
 
+#: scenes/fine_tune.gd
+msgid "FINETUNE_EXPORTING"
+msgstr "Exportiere"
+
 #: scenes/fine_tune.tscn
 msgid "GENERIC_SAVE"
 msgstr "Speichern"

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -523,6 +523,10 @@ msgstr ""
 msgid "FINETUNE_EXPORT"
 msgstr ""
 
+#: scenes/fine_tune.gd
+msgid "FINETUNE_EXPORTING"
+msgstr ""
+
 #: scenes/fine_tune.tscn
 msgid "OpenAI fine-tuning file"
 msgstr ""


### PR DESCRIPTION
## Summary
- Add `export_progress` signal and emit progress updates while converting conversations
- Replace Export button label with progress text during export and restore after completion
- Localize new "Exporting" string for German and English

## Testing
- `godot -e --headless --path src --quit-after 2`
- `for f in src/tests/test_*.gd; do name=$(basename "$f"); godot --headless --path src --script "tests/$name"; done` *(failed: `test_model_output_sample.gd`, `test_schema_title_sync.gd`)*
- `python -m pytest tests/test_schema_align_openai_api.py tests/test_schema_validator_api.py`
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f46f1174c8320a05f3093e80d174c