### PR TITLE
Show download status during image export

### DIFF
--- a/src/scenes/fine_tune.gd
+++ b/src/scenes/fine_tune.gd
@@ -707,8 +707,11 @@ func _end_export_progress():
 	$VBoxContainer/ExportBtn.text = EXPORT_BTN_ORIG_TEXT
 
 
-func _on_export_progress(current: int, total: int) -> void:
-	$VBoxContainer/ExportBtn.text = "%s %d/%d" % [tr("FINETUNE_EXPORTING"), current, total]
+func _on_export_progress(current: int, total: int, text: String = "") -> void:
+	var base_text = tr("FINETUNE_EXPORTING")
+	if text != "":
+		base_text += " " + text
+	$VBoxContainer/ExportBtn.text = "%s %d/%d" % [base_text, current, total]
 
 
 func _on_export_btn_pressed() -> void:

--- a/src/translation/Finetune-Collector_English.po
+++ b/src/translation/Finetune-Collector_English.po
@@ -320,6 +320,10 @@ msgstr "Export Fine-Tune"
 msgid "FINETUNE_EXPORTING"
 msgstr "Exporting"
 
+#: scenes/exporter.gd
+msgid "FINETUNE_EXPORTING_IMAGE_DOWNLOAD"
+msgstr "Downloading image..."
+
 #: scenes/fine_tune.tscn
 msgid "GENERIC_SAVE"
 msgstr "Save"

--- a/src/translation/Finetune-Collector_German.po
+++ b/src/translation/Finetune-Collector_German.po
@@ -332,6 +332,10 @@ msgstr "Exportiere Fine-Tune"
 msgid "FINETUNE_EXPORTING"
 msgstr "Exportiere"
 
+#: scenes/exporter.gd
+msgid "FINETUNE_EXPORTING_IMAGE_DOWNLOAD"
+msgstr "Bild wird heruntergeladen..."
+
 #: scenes/fine_tune.tscn
 msgid "GENERIC_SAVE"
 msgstr "Speichern"

--- a/src/translation/finetune_collector.pot
+++ b/src/translation/finetune_collector.pot
@@ -527,6 +527,10 @@ msgstr ""
 msgid "FINETUNE_EXPORTING"
 msgstr ""
 
+#: scenes/exporter.gd
+msgid "FINETUNE_EXPORTING_IMAGE_DOWNLOAD"
+msgstr ""
+
 #: scenes/fine_tune.tscn
 msgid "OpenAI fine-tuning file"
 msgstr ""


### PR DESCRIPTION
## Summary
- show a status message when an image URL is downloaded and converted to base64 during export
- update export progress button to include optional status text
- add English and German translations for the new download message

## Testing
- `godot -e --headless --path src --quit-after 2`
- `pytest -q`
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f500f68e483209e614b83b92d9d45