### PR TITLE
Copy only grader value to clipboard

### DIFF
--- a/src/scenes/graders/grader_container.gd
+++ b/src/scenes/graders/grader_container.gd
@@ -217,7 +217,8 @@ func _set_grader_controls_disabled(disabled: bool) -> void:
 	_copy_button.disabled = disabled
 
 func _on_copy_grader_to_clipboard_button_pressed() -> void:
-	DisplayServer.clipboard_set(JSON.stringify(to_var()))
+	var data = to_var().get("grader", {})
+	DisplayServer.clipboard_set(JSON.stringify(data))
 
 func to_var():
 	var result = {"use": _use_button.button_pressed, "grader": {}}


### PR DESCRIPTION
## Summary
- copy only the `grader` portion to the clipboard for grader containers

## Testing
- `./check_tabs.sh`
- `godot -e --headless --path src --quit-after 5`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f58e62f108320bc6dac7ce8741b4c