### PR TITLE
Handle legacy JSON Schema message type

### DIFF
--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -91,7 +91,11 @@ func from_var(data):
 		return
 	$MessageSettingsContainer/Role.select(selectionStringToIndex($MessageSettingsContainer/Role, data.get("role", "user")))
 	_on_role_item_selected($MessageSettingsContainer/Role.selected)
-	$MessageSettingsContainer/MessageType.select(selectionStringToIndex($MessageSettingsContainer/MessageType, data.get("type", "Text")))
+	var msg_type = data.get("type", "Text")
+	if msg_type == "JSON Schema":
+		msg_type = "JSON"
+		data["type"] = "JSON"
+	$MessageSettingsContainer/MessageType.select(selectionStringToIndex($MessageSettingsContainer/MessageType, msg_type))
 	_on_message_type_item_selected($MessageSettingsContainer/MessageType.selected)
 	$TextMessageContainer/Message.text = data.get("textContent", "")
 	$TextMessageContainer/DPOMessagesContainer/DPOUnpreferredMsgContainer/DPOUnpreferredMsgEdit.text = data.get("unpreferredTextContent", "")

--- a/src/tests/test_json_schema_message_type_compat.gd
+++ b/src/tests/test_json_schema_message_type_compat.gd
@@ -1,0 +1,26 @@
+extends SceneTree
+
+class DummyFT:
+	extends Node
+	var SETTINGS = {"finetuneType": 0, "useUserNames": false, "tokenCounts": "{}"}
+	func get_available_function_names():
+		return []
+	func get_available_parameter_names_for_function(name):
+		return []
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var ft = DummyFT.new()
+	ft.name = "FineTune"
+	get_root().add_child(ft)
+	var msg = load("res://scenes/message.tscn").instantiate()
+	get_root().add_child(msg)
+	await create_timer(0).timeout
+	msg.from_var({"role": "assistant", "type": "JSON Schema"})
+	var data = msg.to_var()
+	assert(data["type"] == "JSON")
+	print("Legacy JSON Schema message type converted")
+	quit(0)
+

--- a/src/tests/test_json_schema_message_type_compat.gd.uid
+++ b/src/tests/test_json_schema_message_type_compat.gd.uid
@@ -1,0 +1,1 @@
+uid://bog6hcltbd6ra


### PR DESCRIPTION
## Summary
- Convert legacy `JSON Schema` message type to `JSON` when loading messages
- Add regression test for legacy `JSON Schema` message type

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --script tests/test_json_schema_message_type_compat.gd`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: Assertion failed)*
- `godot --headless --path src --script tests/test_schema_validator_request.gd` *(fails: Assertion failed)*
- `python tests/test_schema_align_openai_api.py`
- `python tests/test_schema_validator_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f20f257c832083a2112920aa7bf9