### PR TITLE
Use empty dict for absent function call data

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -352,7 +352,7 @@ func convert_rft_data(ftdata):
 		var reference_json = {}
 		var reference_answer = ""
 		var do_function_call = false
-		var ideal_function_call_data = []
+		var ideal_function_call_data = {}
 		if last_message['type'] == "JSON":
 			reference_json = JSON.parse_string(last_message['jsonSchemaValue'])
 		elif last_message['type'] == "Function Call":

--- a/src/scenes/message.gd
+++ b/src/scenes/message.gd
@@ -1189,7 +1189,7 @@ func get_parameter_values_from_function_parameter_dict(fpdict):
 func to_rft_reference_item():
 	var last_message = to_var()
 	var item = {
-		"ideal_function_call_data": [],
+		"ideal_function_call_data": {},
 		"do_function_call": false
 	}
 	if last_message.get("role", "") != "assistant":

--- a/src/tests/test_copyable_data.gd
+++ b/src/tests/test_copyable_data.gd
@@ -10,7 +10,7 @@ func _run():
 	var container = scene.get_node("GradersListContainer/SampleItemsContainer")
 	var item_edit = container.get_node("SampleItemTextEdit")
 	var model_edit = container.get_node("SampleModelOutputEdit")
-	item_edit.text = '{"do_function_call": false, "ideal_function_call_data": [], "reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
+	item_edit.text = '{"do_function_call": false, "ideal_function_call_data": {}, "reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}'
 	model_edit.text = '{"output_text": "fuzzy", "output_json": {"reference_answer": "...", "moreData": {"a": "Test", "b": "Test"}}, "output_tools": [{"id": "call_0", "type": "function", "function": {"name": "foo"}}]}'
 	scene._update_copyable_data()
 	var datas = []

--- a/src/tests/test_grader_item_wrap.gd
+++ b/src/tests/test_grader_item_wrap.gd
@@ -23,7 +23,7 @@ class OpenAiStub:
 class MessageStub:
 	extends Node
 	func to_rft_reference_item():
-		return {"reference_answer": "fuzzy wuzzy was a bear", "ideal_function_call_data": [], "do_function_call": false}
+		return {"reference_answer": "fuzzy wuzzy was a bear", "ideal_function_call_data": {}, "do_function_call": false}
 	func to_model_output_sample():
 		return {"output_tools": [], "output_text": "fuzzy wuzzy was a bear"}
 	func to_var():


### PR DESCRIPTION
## Summary
- ensure `ideal_function_call_data` is consistently a dictionary when no function call data exists
- update tests to expect empty dictionaries for `ideal_function_call_data`

## Testing
- `./check_tabs.sh`
- `godot --headless --path src --script tests/test_copyable_data.gd`
- `godot --headless --path src --script tests/test_grader_item_wrap.gd`
- `godot --headless --path src --script tests/test_grader.gd`
- `godot --headless --path src --script tests/test_image_url_export.gd`
- `godot --headless --path src --script tests/test_import_openai.gd`
- `godot --headless --path src --script tests/openai_import_test.gd`
- `godot --headless --path src --script tests/test_json_schema_message_type_compat.gd`
- `godot --headless --path src --script tests/test_load_examples.gd`
- `godot --headless --path src --script tests/test_model_output_sample.gd` *(fails: Assertion failed)*
- `godot --headless --path src --script tests/test_rft_text_export.gd`
- `godot --headless --path src --script tests/test_schema_align_openai.gd`
- `godot --headless --path src --script tests/test_schema_title_sync.gd` *(fails: Assertion failed)*
- `godot --headless --path src --script tests/test_schema_validator_request.gd` *(fails: Assertion failed)*
- `godot --headless --path src --script tests/test_application_start.gd`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd7deec08320aa903e6b17628606