### PR TITLE
Ensure final assistant and system messages are exported

### DIFF
--- a/src/scenes/exporter.gd
+++ b/src/scenes/exporter.gd
@@ -503,7 +503,7 @@ func convert_fine_tuning_data(ftdata):
 		_current_total = total
 		emit_signal("export_progress", idx, total, "")
 		await get_tree().process_frame
-		var conversation = conversations[conversation_key]
+		var conversation = conversations[conversation_key].duplicate(true)
 		var processed_conversation = []
 		if system_message:
 			processed_conversation.append({
@@ -512,10 +512,6 @@ func convert_fine_tuning_data(ftdata):
 			})
 		# Convert conversation
 		processed_conversation += await convert_conversation_to_openai_format(conversation, function_map)
-		# Replace system messages with developer role for reinforcement fine tuning
-		for msg in processed_conversation:
-			if msg.get('role', '') == 'system':
-				msg['role'] = 'developer'
 		# Write to JSONL, optionally including tools
 		var output_entry = {
 			'messages': processed_conversation

--- a/src/tests/test_sft_last_message.gd
+++ b/src/tests/test_sft_last_message.gd
@@ -1,0 +1,37 @@
+extends SceneTree
+
+class DummyFineTune:
+	extends Node
+	var SETTINGS = {}
+	func update_settings_internal():
+		pass
+
+func _init():
+	call_deferred("_run")
+
+func _run():
+	var ft = DummyFineTune.new()
+	ft.name = "FineTune"
+	get_root().add_child(ft)
+	var exporter = load("res://scenes/exporter.gd").new()
+	get_root().add_child(exporter)
+	var ftdata = {
+		"functions": [],
+		"settings": {},
+		"conversations": {
+			"c1": [
+				{"role": "system", "type": "Text", "textContent": "sys"},
+				{"role": "user", "type": "Text", "textContent": "Hi"},
+				{"role": "assistant", "type": "Text", "textContent": "Hello"}
+			]
+		}
+	}
+	var result = await exporter.convert_fine_tuning_data(ftdata)
+	var lines = result.strip_edges().split("\n")
+	var parsed = JSON.parse_string(lines[0])
+	var msgs = parsed.get("messages", [])
+	assert(msgs.size() == 3)
+	assert(msgs[0].get("role", "") == "system")
+	assert(msgs[msgs.size() - 1].get("role", "") == "assistant")
+	print("SFT export keeps system and assistant messages")
+	quit(0)

--- a/src/tests/test_sft_last_message.gd.uid
+++ b/src/tests/test_sft_last_message.gd.uid
@@ -1,0 +1,1 @@
+uid://dh04wk8e3s6oy


### PR DESCRIPTION
## Summary
- Avoid mutating conversations and keep system role when exporting supervised fine-tuning data
- Add regression test to verify system and assistant messages are preserved

## Testing
- `godot --headless --path src --script tests/test_sft_last_message.gd`
- `for f in src/tests/*.gd; do echo "Running $f"; godot --headless --path src --script tests/$(basename $f) || break; done` *(fails: File Access Web worked only for HTML5 platform export; Assertion failed output_json: expected bar got)*
- `./check_tabs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a21f6c33e08320898a6d6da09a8a9f