### PR TITLE
Fix parse error in conversation settings scene

### DIFF
--- a/src/scenes/conversation_settings.tscn
+++ b/src/scenes/conversation_settings.tscn
@@ -488,7 +488,6 @@ text = "SETTINGS_IMAGE_UPLOAD_TEST_BUTTON"
 
 [node name="ImageUploadServerTestResultImg" type="TextureRect" parent="VBoxContainer/ImageUploadServerTestContainer"]
 layout_mode = 2
-texture = ExtResource("6_uqjdu")
 stretch_mode = 3
 
 [node name="SchemaSettingsSeparator" type="HSeparator" parent="VBoxContainer"]


### PR DESCRIPTION
## Summary
- remove invalid texture reference from ImageUploadServerTestResultImg to resolve scene parsing error

## Testing
- `godot -e --headless --path src --quit-after 2`
- `for f in src/tests/test_*.gd; do name=$(basename $f); godot --headless --path src --script tests/$name || break; done`
- `pytest tests/test_schema_align_openai_api.py tests/test_schema_validator_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f0a7d524832089b2c6d9881157bd